### PR TITLE
feat(executor): handling invalid destination chain id

### DIFF
--- a/internal/executor/contracts/interchain.go
+++ b/internal/executor/contracts/interchain.go
@@ -280,7 +280,6 @@ func (x *Interchain) HandleIBTP(data []byte) *boltvm.Response {
 	ok = x.Has(x.appchainKey(ibtp.To))
 	if !ok {
 		x.Logger().WithField("chain_id", ibtp.To).Warn("target appchain does not exist")
-		return boltvm.Success(nil)
 	}
 
 	app := &appchain{}


### PR DESCRIPTION
When the destination chain id of ibtp is not exist in bitxhub, its content should still be processed.

close #22