### PR TITLE
refactor(*): deal with DB error in storage

### DIFF
--- a/internal/ledger/chain_meta.go
+++ b/internal/ledger/chain_meta.go
@@ -12,17 +12,11 @@ var (
 )
 
 func loadChainMeta(store storage.Storage) (*pb.ChainMeta, error) {
-	ok, err := store.Has(chainKey)
-	if err != nil {
-		return nil, fmt.Errorf("judge chain meta: %w", err)
-	}
+	ok := store.Has(chainKey)
 
 	chain := &pb.ChainMeta{}
 	if ok {
-		body, err := store.Get(chainKey)
-		if err != nil {
-			return nil, fmt.Errorf("get chain meta: %w", err)
-		}
+		body := store.Get(chainKey)
 
 		if err := chain.Unmarshal(body); err != nil {
 			return nil, fmt.Errorf("unmarshal chain meta: %w", err)

--- a/internal/ledger/journal.go
+++ b/internal/ledger/journal.go
@@ -83,9 +83,9 @@ func getLatestJournal(ldb storage.Storage) (uint64, *BlockJournal, error) {
 }
 
 func getBlockJournal(height uint64, ldb storage.Storage) *BlockJournal {
-	data, err := ldb.Get(compositeKey(journalKey, height))
-	if err != nil {
-		panic(err)
+	data := ldb.Get(compositeKey(journalKey, height))
+	if data == nil {
+		return nil
 	}
 
 	journal := &BlockJournal{}

--- a/internal/ledger/state_accessor.go
+++ b/internal/ledger/state_accessor.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"sort"
 
-	"github.com/syndtr/goleveldb/leveldb/errors"
-
 	"github.com/meshplus/bitxhub-kit/types"
 	"github.com/meshplus/bitxhub-model/pb"
 )
@@ -31,15 +29,7 @@ func (l *ChainLedger) GetAccount(addr types.Address) *Account {
 	}
 
 	account := newAccount(l.ldb, addr)
-	data, err := l.ldb.Get(compositeKey(accountKey, addr.Hex()))
-	if err != nil {
-		if err != errors.ErrNotFound {
-			panic(err)
-		} else {
-			return account
-		}
-	}
-	if data != nil {
+	if data := l.ldb.Get(compositeKey(accountKey, addr.Hex())); data != nil {
 		account.originAccount = &innerAccount{}
 		if err := account.originAccount.Unmarshal(data); err != nil {
 			panic(err)
@@ -144,9 +134,7 @@ func (l *ChainLedger) Commit(height uint64) (types.Hash, error) {
 
 	ldbBatch.Put(compositeKey(journalKey, height), data)
 
-	if err := ldbBatch.Commit(); err != nil {
-		panic(err)
-	}
+	ldbBatch.Commit()
 
 	l.height = height
 	l.prevJournalHash = journalHash

--- a/pkg/order/etcdraft/node.go
+++ b/pkg/order/etcdraft/node.go
@@ -576,9 +576,9 @@ func (n *Node) getBlockAppliedIndex() uint64 {
 
 //Load the lastAppliedIndex of block height
 func (n *Node) loadAppliedIndex() uint64 {
-	dat, err := n.storage.Get(appliedDbKey)
+	dat := n.storage.Get(appliedDbKey)
 	var lastAppliedIndex uint64
-	if err != nil {
+	if dat == nil {
 		lastAppliedIndex = 0
 	} else {
 		lastAppliedIndex = binary.LittleEndian.Uint64(dat)
@@ -591,7 +591,5 @@ func (n *Node) loadAppliedIndex() uint64 {
 func (n *Node) writeAppliedIndex(index uint64) {
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, index)
-	if err := n.storage.Put(appliedDbKey, buf); err != nil {
-		n.logger.Errorf("persisted the latest applied index: %s", err)
-	}
+	n.storage.Put(appliedDbKey, buf)
 }

--- a/pkg/order/etcdraft/txpool/txpool.go
+++ b/pkg/order/etcdraft/txpool/txpool.go
@@ -346,15 +346,13 @@ func compositeKey(value interface{}) []byte {
 func (tp *TxPool) store(tx *pb.Transaction) {
 	txKey := compositeKey(tx.TransactionHash.Bytes())
 	txData, _ := tx.Marshal()
-	if err := tp.storage.Put(txKey, txData); err != nil {
-		tp.logger.Error("store tx error:", err)
-	}
+	tp.storage.Put(txKey, txData)
 }
 
 func (tp *TxPool) load(hash types.Hash) (*pb.Transaction, bool) {
 	txKey := compositeKey(hash.Bytes())
-	txData, err := tp.storage.Get(txKey)
-	if err != nil {
+	txData := tp.storage.Get(txKey)
+	if txData == nil {
 		return nil, false
 	}
 	var tx pb.Transaction
@@ -379,9 +377,7 @@ func (tp *TxPool) BatchStore(hashes []types.Hash) {
 		txData, _ := tx.Marshal()
 		batch.Put(txKey, txData)
 	}
-	if err := batch.Commit(); err != nil {
-		tp.logger.Fatalf("storage batch tx error:", err)
-	}
+	batch.Commit()
 }
 
 //BatchDelete batch delete txs
@@ -391,7 +387,5 @@ func (tp *TxPool) BatchDelete(hashes []types.Hash) {
 		txKey := compositeKey(hash.Bytes())
 		batch.Delete(txKey)
 	}
-	if err := batch.Commit(); err != nil {
-		tp.logger.Fatalf("storage batch tx error:", err)
-	}
+	batch.Commit()
 }

--- a/pkg/order/filter.go
+++ b/pkg/order/filter.go
@@ -25,7 +25,7 @@ type ReqLookUp struct {
 
 func NewReqLookUp(storage storage.Storage, logger logrus.FieldLogger) (*ReqLookUp, error) {
 	filter := bloom.New(m, k)
-	filterDB, _ := storage.Get([]byte(filterDbKey))
+	filterDB := storage.Get([]byte(filterDbKey))
 	if filterDB != nil {
 		var b bytes.Buffer
 		if _, err := b.Write(filterDB); err != nil {
@@ -57,9 +57,7 @@ func (r *ReqLookUp) Build() error {
 	if _, err := r.filter.WriteTo(&r.buffer); err != nil {
 		return err
 	}
-	if err := r.storage.Put([]byte(filterDbKey), r.buffer.Bytes()); err != nil {
-		return err
-	}
+	r.storage.Put([]byte(filterDbKey), r.buffer.Bytes())
 	r.buffer.Reset()
 	return nil
 }

--- a/pkg/storage/leveldb/leveldb.go
+++ b/pkg/storage/leveldb/leveldb.go
@@ -3,6 +3,7 @@ package leveldb
 import (
 	"github.com/meshplus/bitxhub/pkg/storage"
 	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
@@ -21,20 +22,31 @@ func New(path string) (storage.Storage, error) {
 	}, nil
 }
 
-func (l *ldb) Put(key, value []byte) error {
-	return l.db.Put(key, value, nil)
+func (l *ldb) Put(key, value []byte) {
+	if err := l.db.Put(key, value, nil); err != nil {
+		panic(err)
+	}
 }
 
-func (l *ldb) Delete(key []byte) error {
-	return l.db.Delete(key, nil)
+func (l *ldb) Delete(key []byte) {
+	if err := l.db.Delete(key, nil); err != nil {
+		panic(err)
+	}
 }
 
-func (l *ldb) Get(key []byte) (value []byte, err error) {
-	return l.db.Get(key, nil)
+func (l *ldb) Get(key []byte) []byte {
+	val, err := l.db.Get(key, nil)
+	if err != nil {
+		if err == errors.ErrNotFound {
+			return nil
+		}
+		panic(err)
+	}
+	return val
 }
 
-func (l *ldb) Has(key []byte) (exists bool, err error) {
-	return l.db.Has(key, nil)
+func (l *ldb) Has(key []byte) bool {
+	return l.Get(key) != nil
 }
 
 func (l *ldb) Iterator(start, end []byte) storage.Iterator {
@@ -77,6 +89,8 @@ func (l *ldbBatch) Delete(key []byte) {
 	l.batch.Delete(key)
 }
 
-func (l *ldbBatch) Commit() error {
-	return l.ldb.Write(l.batch, nil)
+func (l *ldbBatch) Commit() {
+	if err := l.ldb.Write(l.batch, nil); err != nil {
+		panic(err)
+	}
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -1,14 +1,20 @@
 package storage
 
+import "fmt"
+
+var (
+	ErrorNotFound = fmt.Errorf("not found in DB")
+)
+
 type Storage interface {
 	Write
 
 	// Get retrieves the object `value` named by `key`.
-	// Get will return ErrNotFound if the key is not mapped to a value.
-	Get(key []byte) (value []byte, err error)
+	// Get will return nil if the key is not mapped to a value.
+	Get(key []byte) []byte
 
 	// Has returns whether the `key` is mapped to a `value`.
-	Has(key []byte) (exists bool, err error)
+	Has(key []byte) bool
 
 	// Iterator iterates over a DB's key/value pairs in key order.
 	Iterator(start, end []byte) Iterator
@@ -24,11 +30,10 @@ type Storage interface {
 // Write is the write-side of the storage interface.
 type Write interface {
 	// Put stores the object `value` named by `key`.
-	Put(key, value []byte) error
+	Put(key, value []byte)
 
-	// Delete removes the value for given `key`. If the key is not in the
-	// datastore, this method returns no error.
-	Delete(key []byte) error
+	// Delete removes the value for given `key`.
+	Delete(key []byte)
 }
 
 type Iterator interface {
@@ -57,5 +62,5 @@ type Iterator interface {
 type Batch interface {
 	Put(key, value []byte)
 	Delete(key []byte)
-	Commit() error
+	Commit()
 }


### PR DESCRIPTION
The process panics if DB returns error except errors.ErrNotFound. If DB returns errors.ErrNotFound when it tries to get sth., returns nil data instead.