### PR TITLE
fix(tester): assign transaction hash

### DIFF
--- a/tester/case003_interchain_test.go
+++ b/tester/case003_interchain_test.go
@@ -2,7 +2,6 @@ package tester
 
 import (
 	"encoding/json"
-	"github.com/tidwall/gjson"
 	"io/ioutil"
 	"testing"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/meshplus/bitxhub/internal/constant"
 	"github.com/meshplus/bitxhub/internal/coreapi/api"
 	"github.com/stretchr/testify/suite"
+	"github.com/tidwall/gjson"
 )
 
 type Interchain struct {

--- a/tester/case004_role_test.go
+++ b/tester/case004_role_test.go
@@ -1,6 +1,10 @@
 package tester
 
 import (
+	"encoding/json"
+	"github.com/meshplus/bitxhub-kit/key"
+	"io/ioutil"
+	"path/filepath"
 	"strconv"
 
 	"github.com/meshplus/bitxhub-kit/crypto"
@@ -64,6 +68,7 @@ func (suite *Role) TestGetAdminRoles() {
 }
 
 func (suite *Role) TestIsAdmin() {
+	// Not Admin Chain
 	k, err := ecdsa.GenerateKey(ecdsa.Secp256r1)
 	suite.Require().Nil(err)
 	from, err := k.PublicKey().Address()
@@ -74,4 +79,206 @@ func (suite *Role) TestIsAdmin() {
 	ret, err := strconv.ParseBool(string(r.Ret))
 	suite.Assert().Nil(err)
 	suite.EqualValues(false, ret)
+
+	// Admin Chain
+	path := "./test_data/config/node1/key.json"
+	keyPath := filepath.Join(path)
+	key, err := key.LoadKey(keyPath)
+	suite.Require().Nil(err)
+	priAdmin, err := key.GetPrivateKey("bitxhub")
+	suite.Require().Nil(err)
+	fromAdmin, err := priAdmin.PublicKey().Address()
+	suite.Require().Nil(err)
+
+	r, err = invokeBVMContract(suite.api, priAdmin, constant.RoleContractAddr.Address(), "IsAdmin", pb.String(fromAdmin.Hex()))
+	suite.Require().Nil(err)
+	suite.Require().True(r.IsSuccess())
+	ret, err = strconv.ParseBool(string(r.Ret))
+	suite.Assert().Nil(err)
+	suite.EqualValues(true, ret)
+}
+
+func (suite *Role) TestGetRuleAddress() {
+	k1, err := ecdsa.GenerateKey(ecdsa.Secp256r1)
+	suite.Require().Nil(err)
+	k2, err := ecdsa.GenerateKey(ecdsa.Secp256r1)
+	suite.Require().Nil(err)
+
+	pub1, err := k1.PublicKey().Bytes()
+	suite.Require().Nil(err)
+	pub2, err := k2.PublicKey().Bytes()
+	suite.Require().Nil(err)
+
+	f1, err := k1.PublicKey().Address()
+	suite.Require().Nil(err)
+	f2, err := k2.PublicKey().Address()
+	suite.Require().Nil(err)
+
+	// Register
+	ret, err := invokeBVMContract(suite.api, k1, constant.AppchainMgrContractAddr.Address(), "Register",
+		pb.String(""),
+		pb.Int32(0),
+		pb.String("hyperchain"),
+		pb.String("婚姻链"),
+		pb.String("趣链婚姻链"),
+		pb.String("1.8"),
+		pb.String(string(pub1)),
+	)
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+
+	appchain := Appchain{}
+	err = json.Unmarshal(ret.Ret, &appchain)
+	suite.Require().Nil(err)
+	id1 := appchain.ID
+
+	ret, err = invokeBVMContract(suite.api, k2, constant.AppchainMgrContractAddr.Address(), "Register",
+		pb.String(""),
+		pb.Int32(0),
+		pb.String("fabric"),
+		pb.String("政务链"),
+		pb.String("fabric政务"),
+		pb.String("1.4"),
+		pb.String(string(pub2)),
+	)
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+
+	appchain = Appchain{}
+	err = json.Unmarshal(ret.Ret, &appchain)
+	suite.Require().Nil(err)
+	id2 := appchain.ID
+
+	// deploy rule
+	bytes, err := ioutil.ReadFile("./test_data/hpc_rule.wasm")
+	suite.Require().Nil(err)
+	addr1, err := deployContract(suite.api, k1, bytes)
+	suite.Require().Nil(err)
+
+	bytes, err = ioutil.ReadFile("./test_data/fabric_policy.wasm")
+	suite.Require().Nil(err)
+	addr2, err := deployContract(suite.api, k2, bytes)
+	suite.Require().Nil(err)
+
+	suite.Require().NotEqual(addr1, addr2)
+
+	// register rule
+	ret, err = invokeBVMContract(suite.api, k1, constant.RuleManagerContractAddr.Address(), "RegisterRule", pb.String(f1.Hex()), pb.String(addr1.Hex()))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess())
+
+	ret, err = invokeBVMContract(suite.api, k2, constant.RuleManagerContractAddr.Address(), "RegisterRule", pb.String(f2.Hex()), pb.String(addr2.Hex()))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess())
+
+	// get role address
+	ret, err = invokeBVMContract(suite.api, k1, constant.RuleManagerContractAddr.Address(), "GetRuleAddress", pb.String(string(id1)), pb.String("hyperchain"))
+	suite.Assert().Nil(err)
+	suite.Require().True(ret.IsSuccess())
+	suite.Require().Equal(addr1.String(), string(ret.Ret))
+
+	ret, err = invokeBVMContract(suite.api, k2, constant.RuleManagerContractAddr.Address(), "GetRuleAddress", pb.String(string(id2)), pb.String("fabric"))
+	suite.Assert().Nil(err)
+	suite.Require().True(ret.IsSuccess())
+	suite.Require().Equal(addr2.String(), string(ret.Ret))
+}
+
+func (suite *Role) TestSetAdminRoles() {
+	// admin chain
+	path1 := "./test_data/config/node1/key.json"
+	keyPath1 := filepath.Join(path1)
+	key1, err := key.LoadKey(keyPath1)
+	suite.Require().Nil(err)
+
+	priAdmin, err := key1.GetPrivateKey("bitxhub")
+	suite.Require().Nil(err)
+	fromAdmin, err := priAdmin.PublicKey().Address()
+	suite.Require().Nil(err)
+	pubAdmin, err := priAdmin.PublicKey().Bytes()
+	suite.Require().Nil(err)
+
+	// register
+	retReg, err := invokeBVMContract(suite.api, priAdmin, constant.AppchainMgrContractAddr.Address(), "Register",
+		pb.String(""),
+		pb.Int32(0),
+		pb.String("hyperchain"),
+		pb.String("管理链"),
+		pb.String("趣链管理链"),
+		pb.String("1.8"),
+		pb.String(string(pubAdmin)),
+	)
+	suite.Require().Nil(err)
+	suite.Require().True(retReg.IsSuccess(), string(retReg.Ret))
+
+	// is admin
+	retIsAdmin, err := invokeBVMContract(suite.api, priAdmin, constant.RoleContractAddr.Address(), "IsAdmin", pb.String(fromAdmin.Hex()))
+	suite.Require().Nil(err)
+	suite.Require().True(retIsAdmin.IsSuccess())
+
+	// get admin roles
+	r1, err := invokeBVMContract(suite.api, priAdmin, constant.RoleContractAddr.Address(), "GetAdminRoles")
+	suite.Assert().Nil(err)
+	ret1 := gjson.ParseBytes(r1.Ret)
+	suite.EqualValues(4, len(ret1.Array()))
+
+	as := make([]string, 0)
+	as = append(as, fromAdmin.Hex())
+	data, err := json.Marshal(as)
+	suite.Nil(err)
+
+	// set admin roles
+	r, err := invokeBVMContract(suite.api, priAdmin, constant.RoleContractAddr.Address(), "SetAdminRoles", pb.String(string(data)))
+	suite.Require().Nil(err)
+	suite.Require().True(r.IsSuccess())
+
+	// get admin roles
+	r2, err := invokeBVMContract(suite.api, priAdmin, constant.RoleContractAddr.Address(), "GetAdminRoles")
+	suite.Assert().Nil(err)
+	ret2 := gjson.ParseBytes(r2.Ret)
+	suite.EqualValues(1, len(ret2.Array()))
+
+	// set more admin roles
+	path2 := "./test_data/config/node2/key.json"
+	path3 := "./test_data/config/node3/key.json"
+	path4 := "./test_data/config/node4/key.json"
+
+	keyPath2 := filepath.Join(path2)
+	keyPath3 := filepath.Join(path3)
+	keyPath4 := filepath.Join(path4)
+
+	key2, err := key.LoadKey(keyPath2)
+	suite.Require().Nil(err)
+	key3, err := key.LoadKey(keyPath3)
+	suite.Require().Nil(err)
+	key4, err := key.LoadKey(keyPath4)
+	suite.Require().Nil(err)
+
+	priAdmin2, err := key2.GetPrivateKey("bitxhub")
+	suite.Require().Nil(err)
+	priAdmin3, err := key3.GetPrivateKey("bitxhub")
+	suite.Require().Nil(err)
+	priAdmin4, err := key4.GetPrivateKey("bitxhub")
+	suite.Require().Nil(err)
+
+	fromAdmin2, err := priAdmin2.PublicKey().Address()
+	suite.Require().Nil(err)
+	fromAdmin3, err := priAdmin3.PublicKey().Address()
+	suite.Require().Nil(err)
+	fromAdmin4, err := priAdmin4.PublicKey().Address()
+	suite.Require().Nil(err)
+
+	// set admin roles
+	as2 := make([]string, 0)
+	as2 = append(as2, fromAdmin.Hex(), fromAdmin2.Hex(), fromAdmin3.Hex(), fromAdmin4.Hex())
+	data2, err := json.Marshal(as2)
+	suite.Nil(err)
+	r, err = invokeBVMContract(suite.api, priAdmin, constant.RoleContractAddr.Address(), "SetAdminRoles", pb.String(string(data2)))
+	suite.Require().Nil(err)
+	suite.Require().True(r.IsSuccess())
+
+	// get Admin Roles
+	r3, err := invokeBVMContract(suite.api, priAdmin, constant.RoleContractAddr.Address(), "GetAdminRoles")
+	suite.Assert().Nil(err)
+	ret3 := gjson.ParseBytes(r3.Ret)
+	suite.EqualValues(4, len(ret3.Array()))
 }

--- a/tester/case004_role_test.go
+++ b/tester/case004_role_test.go
@@ -2,13 +2,13 @@ package tester
 
 import (
 	"encoding/json"
-	"github.com/meshplus/bitxhub-kit/key"
 	"io/ioutil"
 	"path/filepath"
 	"strconv"
 
 	"github.com/meshplus/bitxhub-kit/crypto"
 	"github.com/meshplus/bitxhub-kit/crypto/asym/ecdsa"
+	"github.com/meshplus/bitxhub-kit/key"
 	"github.com/meshplus/bitxhub-model/pb"
 	"github.com/meshplus/bitxhub/internal/constant"
 	"github.com/meshplus/bitxhub/internal/coreapi/api"

--- a/tester/case005_store_test.go
+++ b/tester/case005_store_test.go
@@ -1,0 +1,44 @@
+package tester
+
+import (
+	"github.com/meshplus/bitxhub-kit/crypto"
+	"github.com/meshplus/bitxhub-kit/crypto/asym/ecdsa"
+	"github.com/meshplus/bitxhub-model/pb"
+	"github.com/meshplus/bitxhub/internal/constant"
+	"github.com/meshplus/bitxhub/internal/coreapi/api"
+	"github.com/stretchr/testify/suite"
+)
+
+type Store struct {
+	suite.Suite
+	api     api.CoreAPI
+	privKey crypto.PrivateKey
+	pubKey  crypto.PublicKey
+}
+
+func (suite *Store) SetupSuite() {
+	var err error
+	suite.privKey, err = ecdsa.GenerateKey(ecdsa.Secp256r1)
+	suite.Assert().Nil(err)
+
+	suite.pubKey = suite.privKey.PublicKey()
+}
+
+func (suite *Store) TestStore() {
+	k, err := ecdsa.GenerateKey(ecdsa.Secp256r1)
+	suite.Require().Nil(err)
+
+	args := []*pb.Arg{
+		pb.String("123"),
+		pb.String("abc"),
+	}
+
+	ret, err := invokeBVMContract(suite.api, k, constant.StoreContractAddr.Address(), "Set", args...)
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess())
+
+	ret2, err := invokeBVMContract(suite.api, k, constant.StoreContractAddr.Address(), "Get", pb.String("123"))
+	suite.Require().Nil(err)
+	suite.Require().True(ret2.IsSuccess())
+	suite.Require().Equal("abc", string(ret2.Ret))
+}

--- a/tester/helper.go
+++ b/tester/helper.go
@@ -119,6 +119,8 @@ func deployContract(api api.CoreAPI, privateKey crypto.PrivateKey, contract []by
 		Nonce:     rand.Int63(),
 	}
 
+	tx.TransactionHash = tx.Hash()
+
 	if err := tx.Sign(privateKey); err != nil {
 		return types.Address{}, fmt.Errorf("tx sign: %w", err)
 	}

--- a/tester/tester_test.go
+++ b/tester/tester_test.go
@@ -34,6 +34,7 @@ func TestTester(t *testing.T) {
 	suite.Run(t, &RegisterAppchain{api: node2})
 	suite.Run(t, &Interchain{api: node3})
 	suite.Run(t, &Role{api: node4})
+	suite.Run(t, &Store{api: node1})
 }
 
 func setupNode(t *testing.T, path string) api.CoreAPI {


### PR DESCRIPTION
fix(tester): assign transaction hash

Assign transaction hash while deploying contract in test. After this fix, different rules will have different address.