### PR TITLE
fix(tester): assign transaction hash

### DIFF
--- a/tester/helper.go
+++ b/tester/helper.go
@@ -119,6 +119,8 @@ func deployContract(api api.CoreAPI, privateKey crypto.PrivateKey, contract []by
 		Nonce:     rand.Int63(),
 	}
 
+	tx.TransactionHash = tx.Hash()
+
 	if err := tx.Sign(privateKey); err != nil {
 		return types.Address{}, fmt.Errorf("tx sign: %w", err)
 	}


### PR DESCRIPTION
Assign transaction hash while deploying contract in test. After this fix, different rules will have different address.