### PR TITLE
fix(mempool): fix two bugs:

### DIFF
--- a/pkg/order/etcdraft/node.go
+++ b/pkg/order/etcdraft/node.go
@@ -457,12 +457,10 @@ func (n *Node) mint(ready *raftproto.Ready) {
 
 	// follower node update the block height
 	expectHeight := n.mempool.GetChainHeight()
-	if !n.IsLeader() {
-		if expectHeight != ready.Height-1 {
-			n.logger.Warningf("Receive batch %d, but not match, expect height: %d", ready.Height, expectHeight+1)
-			return
-		}
-		n.mempool.IncreaseChainHeight()
+	isLeader := n.IsLeader()
+	if !isLeader && expectHeight != ready.Height-1 {
+		n.logger.Warningf("Receive batch %d, but not match, expect height: %d", ready.Height, expectHeight+1)
+		return
 	}
 
 	missingTxsHash, txList := n.mempool.GetBlock(ready)
@@ -495,6 +493,9 @@ func (n *Node) mint(ready *raftproto.Ready) {
 			n.logger.Error("Still missing transaction")
 			return
 		}
+	}
+	if !isLeader {
+		n.mempool.IncreaseChainHeight()
 	}
 	block := &pb.Block{
 		BlockHeader: &pb.BlockHeader{

--- a/pkg/order/mempool/mempool.go
+++ b/pkg/order/mempool/mempool.go
@@ -76,6 +76,7 @@ func (mpi *mempoolImpl) RecvForwardTxs(txSlice *TxSlice) {
 
 // UpdateLeader updates the
 func (mpi *mempoolImpl) UpdateLeader(newLeader uint64) {
+	// TODO (YH): should block until mempool finishing updating the leader info.
 	mpi.subscribe.updateLeaderC <- newLeader
 }
 


### PR DESCRIPTION
1. If some transactions are missing when calling the func constructSameBatch by a
   follower to construct the same block, avoid persistent this block;
2. Increase the chain height of follower after finishing getting the block from mempool;