### PR TITLE
fix(mempool): fix two mempool bugs:

### DIFF
--- a/pkg/order/mempool/mempool.go
+++ b/pkg/order/mempool/mempool.go
@@ -76,6 +76,7 @@ func (mpi *mempoolImpl) RecvForwardTxs(txSlice *TxSlice) {
 
 // UpdateLeader updates the
 func (mpi *mempoolImpl) UpdateLeader(newLeader uint64) {
+	// TODO (YH): should block until mempool finishing updating the leader info.
 	mpi.subscribe.updateLeaderC <- newLeader
 }
 


### PR DESCRIPTION
1. If some transactions are missing when calling the func constructSameBatch by a
   follower to construct the same block, avoid persistent this block;
2. Increase the chain height of follower after finishing getting the block from mempool;

(cherry picked from commit 5a53cf143504bedf47649c5133b649f2065b5b74)