### PR TITLE
fix(mempool): fix two mempool bugs:

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/magiconair/properties v1.8.1
 	github.com/meshplus/bitxhub-core v0.1.0-rc1.0.20200903124405-b2c62dd8db89
 	github.com/meshplus/bitxhub-kit v1.0.1-0.20200914065214-5161497a783c
-	github.com/meshplus/bitxhub-model v1.0.0-rc4.0.20200927025558-ef1daaa6a629
+	github.com/meshplus/bitxhub-model v1.0.0-rc4.0.20201009112846-79d2e6ddf10d
 	github.com/meshplus/go-lightp2p v0.0.0-20200817105923-6b3aee40fa54
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -546,6 +546,8 @@ github.com/meshplus/bitxhub-model v1.0.0-rc3/go.mod h1:ZCctQIYTlE3vJ8Lhkrgs9bWwN
 github.com/meshplus/bitxhub-model v1.0.0-rc4.0.20200514093243-7e8ae60d1c19/go.mod h1:QK8aACbxtZEA3Hk1BOCirW0uxMWLsMrLDpWz9FweIKM=
 github.com/meshplus/bitxhub-model v1.0.0-rc4.0.20200927025558-ef1daaa6a629 h1:pIzGxvl8l0HtJGIoF0ZUvXB2zXEVqcPA4XcISGSSB+o=
 github.com/meshplus/bitxhub-model v1.0.0-rc4.0.20200927025558-ef1daaa6a629/go.mod h1:QK8aACbxtZEA3Hk1BOCirW0uxMWLsMrLDpWz9FweIKM=
+github.com/meshplus/bitxhub-model v1.0.0-rc4.0.20201009112846-79d2e6ddf10d h1:q4Vig+IVhBvARLyeOsFw8gAdor0ajiBl6lGch1N65sk=
+github.com/meshplus/bitxhub-model v1.0.0-rc4.0.20201009112846-79d2e6ddf10d/go.mod h1:QK8aACbxtZEA3Hk1BOCirW0uxMWLsMrLDpWz9FweIKM=
 github.com/meshplus/go-bitxhub-client v1.0.0-rc3/go.mod h1:FpiCyf6KhydcqthrHdvvPhbPIcD92b+Ju8T7WvQtSyM=
 github.com/meshplus/go-lightp2p v0.0.0-20200817105923-6b3aee40fa54 h1:5Ip5AB7SxxQHg5SRtf2cCOI2wy1p75MQB12soPtPyf8=
 github.com/meshplus/go-lightp2p v0.0.0-20200817105923-6b3aee40fa54/go.mod h1:G89UJaeqCQFxFdp8wzy1AdKfMtDEhpySau0pjDNeeaw=

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018/go.mod h1:rQYf4tfk5sSwFsnDg3qYaBxSjsD9S8+59vW0dKUgme4=
 github.com/davidlazar/go-crypto v0.0.0-20190912175916-7055855a373f h1:BOaYiTvg8p9vBUXpklC22XSK/mifLF7lG9jtmYYi3Tc=
@@ -172,6 +173,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
@@ -651,6 +653,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -745,6 +748,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
@@ -1000,6 +1004,7 @@ gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200601152816-913338de1bd2 h1:VEmvx0P+GVTgkNu2EdTN988YCZPcD3lo9AoczZpucwc=
 gopkg.in/yaml.v3 v3.0.0-20200601152816-913338de1bd2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/order/mempool/mempool.go
+++ b/pkg/order/mempool/mempool.go
@@ -76,6 +76,7 @@ func (mpi *mempoolImpl) RecvForwardTxs(txSlice *TxSlice) {
 
 // UpdateLeader updates the
 func (mpi *mempoolImpl) UpdateLeader(newLeader uint64) {
+	// TODO (YH): should block until mempool finishing updating the leader info.
 	mpi.subscribe.updateLeaderC <- newLeader
 }
 

--- a/pkg/order/mempool/utils.go
+++ b/pkg/order/mempool/utils.go
@@ -144,7 +144,7 @@ func getAccount(tx *pb.Transaction) (string, error) {
 		if err := ibtp.Unmarshal(payload.Args[0].Value); err != nil {
 			return "", fmt.Errorf("unmarshal ibtp from tx :%w", err)
 		}
-		account := fmt.Sprintf("%s-%s-%d", ibtp.From, ibtp.To, ibtp.Type)
+		account := fmt.Sprintf("%s-%s-%d", ibtp.From, ibtp.To, ibtp.Category())
 		return account, nil
 	}
 	return tx.From.Hex(), nil

--- a/tester/case001_api_test.go
+++ b/tester/case001_api_test.go
@@ -55,7 +55,7 @@ func (suite *API) TestSend() {
 }
 
 func testSendTransaction(suite *API) types.Hash {
-	tx, err := genContractTransaction(pb.TransactionData_BVM, suite.privKey,
+	tx, err := genContractTransaction(pb.TransactionData_BVM, suite.privKey, 1,
 		constant.StoreContractAddr.Address(), "Set", pb.String("key"), pb.String(value))
 	suite.Nil(err)
 
@@ -64,7 +64,7 @@ func testSendTransaction(suite *API) types.Hash {
 }
 
 func testSendView(suite *API) {
-	tx, err := genContractTransaction(pb.TransactionData_BVM, suite.privKey,
+	tx, err := genContractTransaction(pb.TransactionData_BVM, suite.privKey, 1,
 		constant.StoreContractAddr.Address(), "Get", pb.String("key"))
 
 	receipt, err := suite.api.Broker().HandleView(tx)

--- a/tester/case002_appchain_test.go
+++ b/tester/case002_appchain_test.go
@@ -60,7 +60,7 @@ func (suite *RegisterAppchain) TestRegisterAppchain() {
 		pb.String(string(pub)),
 	}
 
-	ret, err := invokeBVMContract(suite.api, suite.privKey, constant.AppchainMgrContractAddr.Address(), "Register", args...)
+	ret, err := invokeBVMContract(suite.api, suite.privKey, 1, constant.AppchainMgrContractAddr.Address(), "Register", args...)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
 	suite.Require().Equal("hyperchain", gjson.Get(string(ret.Ret), "chain_type").String())
@@ -71,6 +71,8 @@ func (suite *RegisterAppchain) TestFetchAppchains() {
 	suite.Require().Nil(err)
 	k2, err := asym.GenerateKeyPair(crypto.Secp256k1)
 	suite.Require().Nil(err)
+	k1Nonce := uint64(1)
+	k2Nonce := uint64(1)
 
 	pub1, err := k1.PublicKey().Bytes()
 	suite.Require().Nil(err)
@@ -86,9 +88,10 @@ func (suite *RegisterAppchain) TestFetchAppchains() {
 		pb.String("1.8"),
 		pb.String(string(pub1)),
 	}
-	ret, err := invokeBVMContract(suite.api, k1, constant.AppchainMgrContractAddr.Address(), "Register", args...)
+	ret, err := invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "Register", args...)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
 
 	appchain := Appchain{}
 	err = json.Unmarshal(ret.Ret, &appchain)
@@ -104,44 +107,51 @@ func (suite *RegisterAppchain) TestFetchAppchains() {
 		pb.String("1.4"),
 		pb.String(string(pub2)),
 	}
-	ret, err = invokeBVMContract(suite.api, k2, constant.AppchainMgrContractAddr.Address(), "Register", args...)
+	ret, err = invokeBVMContract(suite.api, k2, k2Nonce, constant.AppchainMgrContractAddr.Address(), "Register", args...)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
 	suite.Require().Nil(err)
+	k2Nonce++
 
-	ret, err = invokeBVMContract(suite.api, k2, constant.AppchainMgrContractAddr.Address(), "Appchains")
+	ret, err = invokeBVMContract(suite.api, k2, k2Nonce, constant.AppchainMgrContractAddr.Address(), "Appchains")
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess())
+	k2Nonce++
 
-	rec, err := invokeBVMContract(suite.api, k2, constant.AppchainMgrContractAddr.Address(), "CountAppchains")
+	rec, err := invokeBVMContract(suite.api, k2, k2Nonce, constant.AppchainMgrContractAddr.Address(), "CountAppchains")
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess())
 	num, err := strconv.Atoi(string(rec.Ret))
 	suite.Require().Nil(err)
 	result := gjson.Parse(string(ret.Ret))
 	suite.Require().GreaterOrEqual(num, len(result.Array()))
+	k2Nonce++
 
-	ret, err = invokeBVMContract(suite.api, k2, constant.AppchainMgrContractAddr.Address(), "CountApprovedAppchains")
+	ret, err = invokeBVMContract(suite.api, k2, k2Nonce, constant.AppchainMgrContractAddr.Address(), "CountApprovedAppchains")
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess())
 	num, err = strconv.Atoi(string(ret.Ret))
 	suite.Require().Nil(err)
 	suite.Require().EqualValues(0, num)
+	k2Nonce++
 
 	//FetchAuditRecords
-	ret, err = invokeBVMContract(suite.api, k1, constant.AppchainMgrContractAddr.Address(), "FetchAuditRecords", pb.String(string(id1)))
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "FetchAuditRecords", pb.String(string(id1)))
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess())
+	k1Nonce++
 
 	//AppChain
-	ret, err = invokeBVMContract(suite.api, k1, constant.AppchainMgrContractAddr.Address(), "Appchain")
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "Appchain")
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess())
+	k1Nonce++
 
 	//GetAppchain
-	ret2, err := invokeBVMContract(suite.api, k2, constant.AppchainMgrContractAddr.Address(), "GetAppchain", pb.String(string(id1)))
+	ret2, err := invokeBVMContract(suite.api, k2, k2Nonce, constant.AppchainMgrContractAddr.Address(), "GetAppchain", pb.String(string(id1)))
 	suite.Require().Nil(err)
 	suite.Require().True(ret2.IsSuccess())
 	suite.Require().Equal(ret.Ret, ret2.Ret)
+	k2Nonce++
 }
 
 func (suite *RegisterAppchain) TestGetPubKeyByChainID() {
@@ -149,6 +159,8 @@ func (suite *RegisterAppchain) TestGetPubKeyByChainID() {
 	suite.Require().Nil(err)
 	k2, err := asym.GenerateKeyPair(crypto.Secp256k1)
 	suite.Require().Nil(err)
+	k1Nonce := uint64(1)
+	k2Nonce := uint64(1)
 
 	pub1, err := k1.PublicKey().Bytes()
 	suite.Require().Nil(err)
@@ -164,9 +176,10 @@ func (suite *RegisterAppchain) TestGetPubKeyByChainID() {
 		pb.String("1.8"),
 		pb.String(string(pub1)),
 	}
-	ret, err := invokeBVMContract(suite.api, k1, constant.AppchainMgrContractAddr.Address(), "Register", args...)
+	ret, err := invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "Register", args...)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
 
 	args = []*pb.Arg{
 		pb.String(""),
@@ -177,9 +190,10 @@ func (suite *RegisterAppchain) TestGetPubKeyByChainID() {
 		pb.String("1.4"),
 		pb.String(string(pub2)),
 	}
-	ret, err = invokeBVMContract(suite.api, k2, constant.AppchainMgrContractAddr.Address(), "Register", args...)
+	ret, err = invokeBVMContract(suite.api, k2, k2Nonce, constant.AppchainMgrContractAddr.Address(), "Register", args...)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
 	suite.Require().Nil(err)
+	k2Nonce++
 
 	appchain2 := Appchain{}
 	err = json.Unmarshal(ret.Ret, &appchain2)
@@ -187,10 +201,11 @@ func (suite *RegisterAppchain) TestGetPubKeyByChainID() {
 	id2 := appchain2.ID
 
 	//GetPubKeyByChainID
-	ret, err = invokeBVMContract(suite.api, k1, constant.AppchainMgrContractAddr.Address(), "GetPubKeyByChainID", pb.String(string(id2)))
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "GetPubKeyByChainID", pb.String(string(id2)))
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess())
 	suite.Require().Equal([]byte(appchain2.PublicKey), ret.Ret)
+	k1Nonce++
 }
 
 func (suite *RegisterAppchain) TestUpdateAppchains() {
@@ -198,6 +213,7 @@ func (suite *RegisterAppchain) TestUpdateAppchains() {
 	suite.Require().Nil(err)
 	pub1, err := k1.PublicKey().Bytes()
 	suite.Require().Nil(err)
+	k1Nonce := uint64(1)
 
 	args := []*pb.Arg{
 		pb.String(""),
@@ -208,9 +224,10 @@ func (suite *RegisterAppchain) TestUpdateAppchains() {
 		pb.String("1.8"),
 		pb.String(string(pub1)),
 	}
-	ret, err := invokeBVMContract(suite.api, k1, constant.AppchainMgrContractAddr.Address(), "Register", args...)
+	ret, err := invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "Register", args...)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
 
 	appchain := Appchain{}
 	err = json.Unmarshal(ret.Ret, &appchain)
@@ -224,6 +241,7 @@ func (suite *RegisterAppchain) TestUpdateAppchains() {
 	suite.Require().Nil(err)
 	pubAdmin, err := priAdmin.PublicKey().Bytes()
 	suite.Require().Nil(err)
+	adminNonce := uint64(1)
 
 	args = []*pb.Arg{
 		pb.String(""),
@@ -234,18 +252,20 @@ func (suite *RegisterAppchain) TestUpdateAppchains() {
 		pb.String("1.0"),
 		pb.String(string(pubAdmin)),
 	}
-	ret, err = invokeBVMContract(suite.api, priAdmin, constant.AppchainMgrContractAddr.Address(), "Register", args...)
+	ret, err = invokeBVMContract(suite.api, priAdmin, adminNonce, constant.AppchainMgrContractAddr.Address(), "Register", args...)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	adminNonce++
 
 	//Audit
-	ret, err = invokeBVMContract(suite.api, priAdmin, constant.AppchainMgrContractAddr.Address(), "Audit",
+	ret, err = invokeBVMContract(suite.api, priAdmin, adminNonce, constant.AppchainMgrContractAddr.Address(), "Audit",
 		pb.String(string(id1)),
 		pb.Int32(1),
 		pb.String("通过"),
 	)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess())
+	adminNonce++
 
 	//UpdateAppchain
 	args = []*pb.Arg{
@@ -257,9 +277,10 @@ func (suite *RegisterAppchain) TestUpdateAppchains() {
 		pb.String("1.9"),
 		pb.String(string(pub1)),
 	}
-	ret, err = invokeBVMContract(suite.api, k1, constant.AppchainMgrContractAddr.Address(), "UpdateAppchain", args...)
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "UpdateAppchain", args...)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess())
+	k1Nonce++
 }
 
 func TestRegisterAppchain(t *testing.T) {

--- a/tester/case003_interchain_test.go
+++ b/tester/case003_interchain_test.go
@@ -33,13 +33,16 @@ func (suite *Interchain) TestHandleIBTP() {
 	suite.Require().Nil(err)
 	t, err := k2.PublicKey().Address()
 	suite.Require().Nil(err)
+	k1Nonce := uint64(1)
+	k2Nonce := uint64(1)
+	ibtpNonce := uint64(1)
 
 	pub1, err := k1.PublicKey().Bytes()
 	suite.Require().Nil(err)
 	pub2, err := k2.PublicKey().Bytes()
 	suite.Require().Nil(err)
 
-	ret, err := invokeBVMContract(suite.api, k1, constant.AppchainMgrContractAddr.Address(), "Register",
+	ret, err := invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "Register",
 		pb.String(""),
 		pb.Int32(0),
 		pb.String("hyperchain"),
@@ -50,8 +53,9 @@ func (suite *Interchain) TestHandleIBTP() {
 	)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
 
-	ret, err = invokeBVMContract(suite.api, k2, constant.AppchainMgrContractAddr.Address(), "Register",
+	ret, err = invokeBVMContract(suite.api, k2, k2Nonce, constant.AppchainMgrContractAddr.Address(), "Register",
 		pb.String(""),
 		pb.Int32(0),
 		pb.String("fabric"),
@@ -62,17 +66,20 @@ func (suite *Interchain) TestHandleIBTP() {
 	)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess())
+	k2Nonce++
 
 	// deploy rule
 	bytes, err := ioutil.ReadFile("./test_data/hpc_rule.wasm")
 	suite.Require().Nil(err)
-	addr, err := deployContract(suite.api, k1, bytes)
+	addr, err := deployContract(suite.api, k1, k1Nonce, bytes)
 	suite.Require().Nil(err)
+	k1Nonce++
 
 	// register rule
-	ret, err = invokeBVMContract(suite.api, k1, constant.RuleManagerContractAddr.Address(), "RegisterRule", pb.String(f.Hex()), pb.String(addr.Hex()))
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.RuleManagerContractAddr.Address(), "RegisterRule", pb.String(f.Hex()), pb.String(addr.Hex()))
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess())
+	k1Nonce++
 
 	proof := []byte("true")
 	proofHash := sha256.Sum256(proof)
@@ -80,13 +87,14 @@ func (suite *Interchain) TestHandleIBTP() {
 	data, err := ib.Marshal()
 	suite.Require().Nil(err)
 
-	tx, err := genBVMContractTransaction(k1, constant.InterchainContractAddr.Address(), "HandleIBTP", pb.Bytes(data))
+	tx, err := genBVMContractTransaction(k1, ibtpNonce, constant.InterchainContractAddr.Address(), "HandleIBTP", pb.Bytes(data))
 	suite.Require().Nil(err)
 
 	tx.Extra = proof
 	ret, err = sendTransactionWithReceipt(suite.api, tx)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	ibtpNonce++
 }
 
 func (suite *Interchain) TestGetIBTPByID() {
@@ -98,6 +106,9 @@ func (suite *Interchain) TestGetIBTPByID() {
 	suite.Require().Nil(err)
 	t, err := k2.PublicKey().Address()
 	suite.Require().Nil(err)
+	k1Nonce := uint64(1)
+	k2Nonce := uint64(1)
+	ibtpNonce := uint64(1)
 
 	pub1, err := k1.PublicKey().Bytes()
 	suite.Require().Nil(err)
@@ -107,7 +118,7 @@ func (suite *Interchain) TestGetIBTPByID() {
 	confByte, err := ioutil.ReadFile("./test_data/validator")
 	suite.Require().Nil(err)
 
-	ret, err := invokeBVMContract(suite.api, k1, constant.AppchainMgrContractAddr.Address(), "Register",
+	ret, err := invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "Register",
 		pb.String(string(confByte)),
 		pb.Int32(0),
 		pb.String("hyperchain"),
@@ -118,8 +129,9 @@ func (suite *Interchain) TestGetIBTPByID() {
 	)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
 
-	ret, err = invokeBVMContract(suite.api, k2, constant.AppchainMgrContractAddr.Address(), "Register",
+	ret, err = invokeBVMContract(suite.api, k2, k2Nonce, constant.AppchainMgrContractAddr.Address(), "Register",
 		pb.String(""),
 		pb.Int32(0),
 		pb.String("fabric"),
@@ -130,15 +142,18 @@ func (suite *Interchain) TestGetIBTPByID() {
 	)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k2Nonce++
 
 	contractByte, err := ioutil.ReadFile("./test_data/fabric_policy.wasm")
 	suite.Require().Nil(err)
-	addr, err := deployContract(suite.api, k1, contractByte)
+	addr, err := deployContract(suite.api, k1, k1Nonce, contractByte)
 	suite.Require().Nil(err)
+	k1Nonce++
 
 	// register rule
-	_, err = invokeBVMContract(suite.api, k1, constant.RuleManagerContractAddr.Address(), "RegisterRule", pb.String(f.Hex()), pb.String(addr.Hex()))
+	_, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.RuleManagerContractAddr.Address(), "RegisterRule", pb.String(f.Hex()), pb.String(addr.Hex()))
 	suite.Require().Nil(err)
+	k1Nonce++
 
 	proof, err := ioutil.ReadFile("./test_data/proof")
 	suite.Require().Nil(err)
@@ -148,61 +163,68 @@ func (suite *Interchain) TestGetIBTPByID() {
 	data, err := ib.Marshal()
 	suite.Require().Nil(err)
 
-	tx, err := genBVMContractTransaction(k1, constant.InterchainContractAddr.Address(), "HandleIBTP", pb.Bytes(data))
+	tx, err := genBVMContractTransaction(k1, ibtpNonce, constant.InterchainContractAddr.Address(), "HandleIBTP", pb.Bytes(data))
 	suite.Require().Nil(err)
 	tx.Extra = proof
 	receipt, err := sendTransactionWithReceipt(suite.api, tx)
 	suite.Require().Nil(err)
 	suite.Require().EqualValues(true, receipt.IsSuccess(), string(receipt.Ret))
+	ibtpNonce++
 
 	ib.Index = 2
 	data, err = ib.Marshal()
 	suite.Require().Nil(err)
 
-	tx, err = genBVMContractTransaction(k1, constant.InterchainContractAddr.Address(), "HandleIBTP", pb.Bytes(data))
+	tx, err = genBVMContractTransaction(k1, ibtpNonce, constant.InterchainContractAddr.Address(), "HandleIBTP", pb.Bytes(data))
 	suite.Require().Nil(err)
 	tx.Extra = proof
 	receipt, err = sendTransactionWithReceipt(suite.api, tx)
 	suite.Require().Nil(err)
 	suite.Require().EqualValues(true, receipt.IsSuccess(), string(receipt.Ret))
+	ibtpNonce++
 
 	ib.Index = 3
 	data, err = ib.Marshal()
 	suite.Assert().Nil(err)
 
-	tx, err = genBVMContractTransaction(k1, constant.InterchainContractAddr.Address(), "HandleIBTP", pb.Bytes(data))
+	tx, err = genBVMContractTransaction(k1, ibtpNonce, constant.InterchainContractAddr.Address(), "HandleIBTP", pb.Bytes(data))
 	suite.Require().Nil(err)
 	tx.Extra = proof
 	receipt, err = sendTransactionWithReceipt(suite.api, tx)
 	suite.Assert().Nil(err)
+	ibtpNonce++
 
 	ib.Index = 2
-	ret, err = invokeBVMContract(suite.api, k1, constant.InterchainContractAddr.Address(), "GetIBTPByID", pb.String(ib.ID()))
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.InterchainContractAddr.Address(), "GetIBTPByID", pb.String(ib.ID()))
 	suite.Assert().Nil(err)
 	suite.Assert().Equal(true, ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
 }
 
 func (suite *Interchain) TestAudit() {
 	k, err := asym.GenerateKeyPair(crypto.Secp256k1)
 	suite.Require().Nil(err)
+	kNonce := uint64(1)
 
-	ret, err := invokeBVMContract(suite.api, k, constant.AppchainMgrContractAddr.Address(), "Audit",
+	ret, err := invokeBVMContract(suite.api, k, kNonce, constant.AppchainMgrContractAddr.Address(), "Audit",
 		pb.String("0x123"),
 		pb.Int32(1),
 		pb.String("通过"),
 	)
 	suite.Require().Nil(err)
 	suite.Contains(string(ret.Ret), "caller is not an admin account")
+	kNonce++
 }
 
 func (suite *Interchain) TestInterchain() {
 	k1, err := asym.GenerateKeyPair(crypto.Secp256k1)
 	suite.Require().Nil(err)
+	k1Nonce := uint64(1)
 
 	pub1, err := k1.PublicKey().Bytes()
 	suite.Require().Nil(err)
 
-	ret, err := invokeBVMContract(suite.api, k1, constant.AppchainMgrContractAddr.Address(), "Register",
+	ret, err := invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "Register",
 		pb.String(""),
 		pb.Int32(0),
 		pb.String("hyperchain"),
@@ -213,28 +235,32 @@ func (suite *Interchain) TestInterchain() {
 	)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
 
 	appchain := Appchain{}
 	err = json.Unmarshal(ret.Ret, &appchain)
 	suite.Require().Nil(err)
 	id1 := appchain.ID
 
-	ret, err = invokeBVMContract(suite.api, k1, constant.InterchainContractAddr.Address(), "Interchain")
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.InterchainContractAddr.Address(), "Interchain")
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
 	suite.Require().Equal(id1, gjson.Get(string(ret.Ret), "id").String())
 	suite.Require().Equal("", gjson.Get(string(ret.Ret), "interchain_counter").String())
 	suite.Require().Equal("", gjson.Get(string(ret.Ret), "receipt_counter").String())
 	suite.Require().Equal("", gjson.Get(string(ret.Ret), "source_receipt_counter").String())
+	k1Nonce++
 }
 
 func (suite *Interchain) TestRegister() {
 	k1, err := asym.GenerateKeyPair(crypto.Secp256k1)
 	suite.Require().Nil(err)
+	k1Nonce := uint64(1)
 
-	ret, err := invokeBVMContract(suite.api, k1, constant.InterchainContractAddr.Address(), "Register")
+	ret, err := invokeBVMContract(suite.api, k1, k1Nonce, constant.InterchainContractAddr.Address(), "Register")
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
 }
 
 func TestInterchain(t *testing.T) {

--- a/tester/case005_store_test.go
+++ b/tester/case005_store_test.go
@@ -27,18 +27,21 @@ func (suite *Store) SetupSuite() {
 func (suite *Store) TestStore() {
 	k, err := asym.GenerateKeyPair(crypto.Secp256k1)
 	suite.Require().Nil(err)
+	kNonce := uint64(1)
 
 	args := []*pb.Arg{
 		pb.String("123"),
 		pb.String("abc"),
 	}
 
-	ret, err := invokeBVMContract(suite.api, k, constant.StoreContractAddr.Address(), "Set", args...)
+	ret, err := invokeBVMContract(suite.api, k, kNonce, constant.StoreContractAddr.Address(), "Set", args...)
 	suite.Require().Nil(err)
 	suite.Require().True(ret.IsSuccess())
+	kNonce++
 
-	ret2, err := invokeBVMContract(suite.api, k, constant.StoreContractAddr.Address(), "Get", pb.String("123"))
+	ret2, err := invokeBVMContract(suite.api, k, kNonce, constant.StoreContractAddr.Address(), "Get", pb.String("123"))
 	suite.Require().Nil(err)
 	suite.Require().True(ret2.IsSuccess())
 	suite.Require().Equal("abc", string(ret2.Ret))
+	kNonce++
 }

--- a/tester/helper.go
+++ b/tester/helper.go
@@ -3,7 +3,6 @@ package tester
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"strings"
 	"time"
 
@@ -14,16 +13,16 @@ import (
 	"github.com/meshplus/bitxhub-model/pb"
 )
 
-func genBVMContractTransaction(privateKey crypto.PrivateKey, address types.Address, method string, args ...*pb.Arg) (*pb.Transaction, error) {
-	return genContractTransaction(pb.TransactionData_BVM, privateKey, address, method, args...)
+func genBVMContractTransaction(privateKey crypto.PrivateKey, nonce uint64, address types.Address, method string, args ...*pb.Arg) (*pb.Transaction, error) {
+	return genContractTransaction(pb.TransactionData_BVM, privateKey, nonce, address, method, args...)
 }
 
-func genXVMContractTransaction(privateKey crypto.PrivateKey, address types.Address, method string, args ...*pb.Arg) (*pb.Transaction, error) {
-	return genContractTransaction(pb.TransactionData_XVM, privateKey, address, method, args...)
+func genXVMContractTransaction(privateKey crypto.PrivateKey, nonce uint64, address types.Address, method string, args ...*pb.Arg) (*pb.Transaction, error) {
+	return genContractTransaction(pb.TransactionData_XVM, privateKey, nonce, address, method, args...)
 }
 
-func invokeBVMContract(api api.CoreAPI, privateKey crypto.PrivateKey, address types.Address, method string, args ...*pb.Arg) (*pb.Receipt, error) {
-	tx, err := genBVMContractTransaction(privateKey, address, method, args...)
+func invokeBVMContract(api api.CoreAPI, privateKey crypto.PrivateKey, nonce uint64, address types.Address, method string, args ...*pb.Arg) (*pb.Receipt, error) {
+	tx, err := genBVMContractTransaction(privateKey, nonce, address, method, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +60,7 @@ func sendTransactionWithReceipt(api api.CoreAPI, tx *pb.Transaction) (*pb.Receip
 
 }
 
-func genContractTransaction(vmType pb.TransactionData_VMType, privateKey crypto.PrivateKey, address types.Address, method string, args ...*pb.Arg) (*pb.Transaction, error) {
+func genContractTransaction(vmType pb.TransactionData_VMType, privateKey crypto.PrivateKey, nonce uint64, address types.Address, method string, args ...*pb.Arg) (*pb.Transaction, error) {
 	from, err := privateKey.PublicKey().Address()
 	if err != nil {
 		return nil, err
@@ -88,7 +87,7 @@ func genContractTransaction(vmType pb.TransactionData_VMType, privateKey crypto.
 		To:        address,
 		Data:      td,
 		Timestamp: time.Now().UnixNano(),
-		Nonce:     uint64(rand.Int63()),
+		Nonce:     nonce,
 	}
 
 	if err := tx.Sign(privateKey); err != nil {
@@ -100,7 +99,7 @@ func genContractTransaction(vmType pb.TransactionData_VMType, privateKey crypto.
 	return tx, nil
 }
 
-func deployContract(api api.CoreAPI, privateKey crypto.PrivateKey, contract []byte) (types.Address, error) {
+func deployContract(api api.CoreAPI, privateKey crypto.PrivateKey, nonce uint64, contract []byte) (types.Address, error) {
 	from, err := privateKey.PublicKey().Address()
 	if err != nil {
 		return types.Address{}, err
@@ -116,7 +115,7 @@ func deployContract(api api.CoreAPI, privateKey crypto.PrivateKey, contract []by
 		From:      from,
 		Data:      td,
 		Timestamp: time.Now().UnixNano(),
-		Nonce:     uint64(rand.Int63()),
+		Nonce:     nonce,
 	}
 
 	tx.TransactionHash = tx.Hash()


### PR DESCRIPTION
1. If some transactions are missing when calling the func constructSameBatch by a
   follower to construct the same block, avoid persistent this block;
2. Increase the chain height of follower after finishing getting the block from mempool;

(cherry picked from commit 5a53cf143504bedf47649c5133b649f2065b5b74)