### PR TITLE
fix(cmd): fix "bitxhub key show" command with wrong path

### DIFF
--- a/cmd/bitxhub/key.go
+++ b/cmd/bitxhub/key.go
@@ -55,12 +55,6 @@ func keyCMD() cli.Command {
 				Name:   "show",
 				Usage:  "Show key from cert",
 				Action: showKey,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "path",
-						Usage: "Node Path",
-					},
-				},
 			},
 			{
 				Name:   "address",


### PR DESCRIPTION
fix "btxhub key show" command should return error but not bug