### PR TITLE
fix(*): fix a bug about wrong objid in rule management

### DIFF
--- a/internal/executor/contracts/rule_manager.go
+++ b/internal/executor/contracts/rule_manager.go
@@ -218,7 +218,7 @@ func (rm *RuleManager) bindRule(chainId string, ruleAddr string, event governanc
 		pb.String(string(event)),
 		pb.String(""),
 		pb.String(string(RuleMgr)),
-		pb.String(ruleAddr),
+		pb.String(RuleKey(chainId)),
 		pb.String(string(rule.Status)),
 		pb.Bytes(ruleRes.Result),
 	)


### PR DESCRIPTION
The objID of rule management is the appchain ID rather than the rule address