### PR TITLE
feat(raft): adjust the order start sequence

### DIFF
--- a/goent.diff
+++ b/goent.diff
@@ -1,6 +1,6 @@
     github.com/bitxhub/parallel-executor v0.0.0-20210603034349-c18e7ed17048
     github.com/bitxhub/service-mng v0.0.0-20201125031105-f345beee1b42
-	github.com/bitxhub/bitxhub-order-rbft v0.0.0-20210817110755-2e31641f3b91
+	github.com/bitxhub/bitxhub-order-rbft v0.0.0-20210827023248-16204be14339
     github.com/bitxhub/license v0.0.0-20210721031301-66d44925f5f9
 
 replace github.com/ultramesh/rbft => git.hyperchain.cn/ultramesh/rbft v0.1.5-0.20210817012908-9d35a610a919

--- a/pkg/order/etcdraft/node_test.go
+++ b/pkg/order/etcdraft/node_test.go
@@ -44,9 +44,11 @@ func TestNode_Start(t *testing.T) {
 	mockPeermgr := mock_peermgr.NewMockPeerManager(mockCtl)
 	peers := make(map[uint64]*pb.VpInfo)
 	otherPeers := make(map[uint64]*peer.AddrInfo, 5)
+	cntPeers := uint64(0)
 	mockPeermgr.EXPECT().Peers().Return(peers).AnyTimes()
 	mockPeermgr.EXPECT().OtherPeers().Return(otherPeers).AnyTimes()
 	mockPeermgr.EXPECT().Broadcast(gomock.Any()).AnyTimes()
+	mockPeermgr.EXPECT().CountConnectedPeers().Return(cntPeers).AnyTimes()
 
 	order, err := NewNode(
 		order.WithRepoRoot(repoRoot),
@@ -246,6 +248,7 @@ func TestRun(t *testing.T) {
 	node.checkInterval = 200 * time.Millisecond
 	err = node.Start()
 	ast.Nil(err)
+	ast.Nil(node.checkQuorum())
 	// test confChangeC
 	node.confChangeC <- raftpb.ConfChange{ID: uint64(2)}
 	// test rebroadcastTicker


### PR DESCRIPTION
- Ensure that the number of connected peers reaches Quorum when the order is started.

- feat(rbft): update go mod.