### PR TITLE
fix(*): fix bugs in the association between appchain governance and rule governance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.5.6
 	github.com/looplab/fsm v0.2.0
 	github.com/magiconair/properties v1.8.4
-	github.com/meshplus/bitxhub-core v1.3.1-0.20210906011130-82a06fa0ab2c
+	github.com/meshplus/bitxhub-core v1.3.1-0.20210906033128-dada2778063e
 	github.com/meshplus/bitxhub-kit v1.2.1-0.20210901014031-ee93dd4f4ced
 	github.com/meshplus/bitxhub-model v1.2.1-0.20210902030154-b203e4a4b3de
 	github.com/meshplus/eth-kit v0.0.0-20210827081722-ce80fe3a863b

--- a/go.sum
+++ b/go.sum
@@ -772,8 +772,8 @@ github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4f
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/meshplus/bitxhub-core v1.3.1-0.20210906011130-82a06fa0ab2c h1:qRs3uZ2OJiloR0wIxy7G5bhJ8GamNhB8AtP6wrWGhSk=
-github.com/meshplus/bitxhub-core v1.3.1-0.20210906011130-82a06fa0ab2c/go.mod h1:UZ7oyOS+H2aXd2w2P+AwYiB7UO3xZCNP83w6mUJwqu4=
+github.com/meshplus/bitxhub-core v1.3.1-0.20210906033128-dada2778063e h1:p1nnBxoiyC8xsvbbmsofWBPc/UvTHyT5evVaX3syoQY=
+github.com/meshplus/bitxhub-core v1.3.1-0.20210906033128-dada2778063e/go.mod h1:UZ7oyOS+H2aXd2w2P+AwYiB7UO3xZCNP83w6mUJwqu4=
 github.com/meshplus/bitxhub-kit v1.1.1/go.mod h1:r4l4iqn0RPJreb/OmoYKfjCjQJrXpZX++6Qc31VG/1k=
 github.com/meshplus/bitxhub-kit v1.2.1-0.20210616114532-4849447f09e1/go.mod h1:wrEdhHp1tktzdwcWb4bOxYsVc+KkcrYL18IYWYeumPQ=
 github.com/meshplus/bitxhub-kit v1.2.1-0.20210830031953-cf5f83f2e1dd/go.mod h1:wrEdhHp1tktzdwcWb4bOxYsVc+KkcrYL18IYWYeumPQ=

--- a/internal/executor/contracts/appchain_manager_test.go
+++ b/internal/executor/contracts/appchain_manager_test.go
@@ -184,6 +184,7 @@ func TestManageChain(t *testing.T) {
 	mockStub.EXPECT().CrossInvoke(constant.GovernanceContractAddr.Address().String(), "SubmitProposal", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(boltvm.Success(nil)).AnyTimes()
 	mockStub.EXPECT().CrossInvoke(constant.RoleContractAddr.Address().String(), "GetAppchainAdmin", gomock.Any()).Return(boltvm.Success(rolesData[0])).AnyTimes()
 	mockStub.EXPECT().CrossInvoke(constant.RoleContractAddr.Address().String(), "IsAnyAvailableAdmin", pb.String(appchainAdminAddr), pb.String(string(GovernanceAdmin))).Return(boltvm.Success([]byte(TRUE))).AnyTimes()
+	mockStub.EXPECT().CrossInvoke(constant.ServiceMgrContractAddr.Address().String(), "PauseChainService", gomock.Any()).Return(boltvm.Success(nil)).AnyTimes()
 
 	availableChain := chains[0]
 	availableChain.Status = governance.GovernanceAvailable

--- a/tester/case008_service_test.go
+++ b/tester/case008_service_test.go
@@ -82,13 +82,13 @@ func (suite *Service) TestRegisterService() {
 	suite.Require().Nil(err)
 	proposalId1 := gRet.ProposalID
 
-	suite.vote(proposalId1, priAdmin1, adminNonce1)
+	suite.vote(proposalId1, priAdmin1, adminNonce1, string(contracts.APPOVED))
 	adminNonce1++
 
-	suite.vote(proposalId1, priAdmin2, adminNonce2)
+	suite.vote(proposalId1, priAdmin2, adminNonce2, string(contracts.APPOVED))
 	adminNonce2++
 
-	suite.vote(proposalId1, priAdmin3, adminNonce3)
+	suite.vote(proposalId1, priAdmin3, adminNonce3, string(contracts.APPOVED))
 	adminNonce3++
 
 	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "GetAppchain", pb.String(chainID1))
@@ -119,13 +119,13 @@ func (suite *Service) TestRegisterService() {
 	suite.Require().Nil(err)
 	proposalServiceId1 := gRet.ProposalID
 
-	suite.vote(proposalServiceId1, priAdmin1, adminNonce1)
+	suite.vote(proposalServiceId1, priAdmin1, adminNonce1, string(contracts.APPOVED))
 	adminNonce1++
 
-	suite.vote(proposalServiceId1, priAdmin2, adminNonce2)
+	suite.vote(proposalServiceId1, priAdmin2, adminNonce2, string(contracts.APPOVED))
 	adminNonce2++
 
-	suite.vote(proposalServiceId1, priAdmin3, adminNonce3)
+	suite.vote(proposalServiceId1, priAdmin3, adminNonce3, string(contracts.APPOVED))
 	adminNonce3++
 
 	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "GetServiceInfo", pb.String(chainServiceID1))
@@ -173,13 +173,13 @@ func (suite *Service) TestRegisterService() {
 	suite.Require().Nil(err)
 	proposalFreezeAppchainId := gRet.ProposalID
 
-	suite.vote(proposalFreezeAppchainId, priAdmin1, adminNonce1)
+	suite.vote(proposalFreezeAppchainId, priAdmin1, adminNonce1, string(contracts.APPOVED))
 	adminNonce1++
 
-	suite.vote(proposalFreezeAppchainId, priAdmin2, adminNonce2)
+	suite.vote(proposalFreezeAppchainId, priAdmin2, adminNonce2, string(contracts.APPOVED))
 	adminNonce2++
 
-	suite.vote(proposalFreezeAppchainId, priAdmin3, adminNonce3)
+	suite.vote(proposalFreezeAppchainId, priAdmin3, adminNonce3, string(contracts.APPOVED))
 	adminNonce3++
 
 	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "GetAppchain", pb.String(chainID1))
@@ -210,13 +210,13 @@ func (suite *Service) TestRegisterService() {
 	suite.Require().Nil(err)
 	proposalActivateAppchainId := gRet.ProposalID
 
-	suite.vote(proposalActivateAppchainId, priAdmin1, adminNonce1)
+	suite.vote(proposalActivateAppchainId, priAdmin1, adminNonce1, string(contracts.APPOVED))
 	adminNonce1++
 
-	suite.vote(proposalActivateAppchainId, priAdmin2, adminNonce2)
+	suite.vote(proposalActivateAppchainId, priAdmin2, adminNonce2, string(contracts.APPOVED))
 	adminNonce2++
 
-	suite.vote(proposalActivateAppchainId, priAdmin3, adminNonce3)
+	suite.vote(proposalActivateAppchainId, priAdmin3, adminNonce3, string(contracts.APPOVED))
 	adminNonce3++
 
 	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "GetAppchain", pb.String(chainID1))
@@ -236,10 +236,399 @@ func (suite *Service) TestRegisterService() {
 	suite.Equal(governance.GovernanceUpdating, service.Status)
 }
 
-func (suite *Service) vote(proposalId string, adminKey crypto.PrivateKey, adminNonce uint64) {
+func (suite *Service) TestLogoutAppchainPauseService() {
+	path1 := "./test_data/config/node1/key.json"
+	path2 := "./test_data/config/node2/key.json"
+	path3 := "./test_data/config/node3/key.json"
+	keyPath1 := filepath.Join(path1)
+	keyPath2 := filepath.Join(path2)
+	keyPath3 := filepath.Join(path3)
+	priAdmin1, err := asym.RestorePrivateKey(keyPath1, "bitxhub")
+	suite.Require().Nil(err)
+	priAdmin2, err := asym.RestorePrivateKey(keyPath2, "bitxhub")
+	suite.Require().Nil(err)
+	priAdmin3, err := asym.RestorePrivateKey(keyPath3, "bitxhub")
+	suite.Require().Nil(err)
+	fromAdmin1, err := priAdmin1.PublicKey().Address()
+	suite.Require().Nil(err)
+	fromAdmin2, err := priAdmin2.PublicKey().Address()
+	suite.Require().Nil(err)
+	fromAdmin3, err := priAdmin3.PublicKey().Address()
+	suite.Require().Nil(err)
+	adminNonce1 := suite.api.Broker().GetPendingNonceByAccount(fromAdmin1.String())
+	adminNonce2 := suite.api.Broker().GetPendingNonceByAccount(fromAdmin2.String())
+	adminNonce3 := suite.api.Broker().GetPendingNonceByAccount(fromAdmin3.String())
+
+	k1, err := asym.GenerateKeyPair(crypto.Secp256k1)
+	suite.Require().Nil(err)
+	k2, err := asym.GenerateKeyPair(crypto.Secp256k1)
+	suite.Require().Nil(err)
+	suite.Require().Nil(err)
+	addr1, err := k1.PublicKey().Address()
+	suite.Require().Nil(err)
+	addr2, err := k2.PublicKey().Address()
+	suite.Require().Nil(err)
+	suite.Require().Nil(transfer(suite.Suite, suite.api, addr1, 10000000000000))
+	suite.Require().Nil(transfer(suite.Suite, suite.api, addr2, 10000000000000))
+	k1Nonce := suite.api.Broker().GetPendingNonceByAccount(addr1.String())
+
+	chainID1 := fmt.Sprintf("appchain%s", addr1.String())
+	serviceID1 := "service1"
+	chainServiceID1 := fmt.Sprintf("%s:%s", chainID1, serviceID1)
+
+	ret, err := invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "RegisterAppchain",
+		pb.String(chainID1),
+		pb.Bytes(nil),
+		pb.String("broker"),
+		pb.String("desc"),
+		pb.String(validator.FabricRuleAddr),
+		pb.String("reason"),
+	)
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	gRet := &governance.GovernanceResult{}
+	err = json.Unmarshal(ret.Ret, gRet)
+	suite.Require().Nil(err)
+	proposalRegisterAppchainId := gRet.ProposalID
+
+	suite.vote(proposalRegisterAppchainId, priAdmin1, adminNonce1, string(contracts.APPOVED))
+	adminNonce1++
+
+	suite.vote(proposalRegisterAppchainId, priAdmin2, adminNonce2, string(contracts.APPOVED))
+	adminNonce2++
+
+	suite.vote(proposalRegisterAppchainId, priAdmin3, adminNonce3, string(contracts.APPOVED))
+	adminNonce3++
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "GetAppchain", pb.String(chainID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	appchain := &appchainMgr.Appchain{}
+	err = json.Unmarshal(ret.Ret, appchain)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernanceAvailable, appchain.Status)
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "RegisterService",
+		pb.String(chainID1),
+		pb.String(serviceID1),
+		pb.String("name"),
+		pb.String(string(service_mgr.ServiceCallContract)),
+		pb.String("intro"),
+		pb.Bool(true),
+		pb.String(""),
+		pb.String("details"),
+		pb.String("raeson"),
+	)
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	gRet = &governance.GovernanceResult{}
+	err = json.Unmarshal(ret.Ret, gRet)
+	suite.Require().Nil(err)
+	proposalServiceId := gRet.ProposalID
+
+	suite.vote(proposalServiceId, priAdmin1, adminNonce1, string(contracts.APPOVED))
+	adminNonce1++
+
+	suite.vote(proposalServiceId, priAdmin2, adminNonce2, string(contracts.APPOVED))
+	adminNonce2++
+
+	suite.vote(proposalServiceId, priAdmin3, adminNonce3, string(contracts.APPOVED))
+	adminNonce3++
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "GetServiceInfo", pb.String(chainServiceID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	service := &service_mgr.Service{}
+	err = json.Unmarshal(ret.Ret, service)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernanceAvailable, service.Status)
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "LogoutAppchain",
+		pb.String(chainID1),
+		pb.String("raeson"),
+	)
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	gRet = &governance.GovernanceResult{}
+	err = json.Unmarshal(ret.Ret, gRet)
+	suite.Require().Nil(err)
+	proposalLogoutAppchainID := gRet.ProposalID
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "GetServiceInfo", pb.String(chainServiceID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	err = json.Unmarshal(ret.Ret, service)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernancePause, service.Status)
+
+	suite.vote(proposalLogoutAppchainID, priAdmin1, adminNonce1, string(contracts.REJECTED))
+	adminNonce1++
+
+	suite.vote(proposalLogoutAppchainID, priAdmin2, adminNonce2, string(contracts.REJECTED))
+	adminNonce2++
+
+	suite.vote(proposalLogoutAppchainID, priAdmin3, adminNonce3, string(contracts.REJECTED))
+	adminNonce3++
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "GetAppchain", pb.String(chainID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	err = json.Unmarshal(ret.Ret, appchain)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernanceAvailable, appchain.Status)
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "GetServiceInfo", pb.String(chainServiceID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	err = json.Unmarshal(ret.Ret, service)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernanceAvailable, service.Status)
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "LogoutAppchain",
+		pb.String(chainID1),
+		pb.String("raeson"),
+	)
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	gRet = &governance.GovernanceResult{}
+	err = json.Unmarshal(ret.Ret, gRet)
+	suite.Require().Nil(err)
+	proposalLogoutAppchainID2 := gRet.ProposalID
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "GetServiceInfo", pb.String(chainServiceID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	err = json.Unmarshal(ret.Ret, service)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernancePause, service.Status)
+
+	suite.vote(proposalLogoutAppchainID2, priAdmin1, adminNonce1, string(contracts.APPOVED))
+	adminNonce1++
+
+	suite.vote(proposalLogoutAppchainID2, priAdmin2, adminNonce2, string(contracts.APPOVED))
+	adminNonce2++
+
+	suite.vote(proposalLogoutAppchainID2, priAdmin3, adminNonce3, string(contracts.APPOVED))
+	adminNonce3++
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "GetAppchain", pb.String(chainID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	err = json.Unmarshal(ret.Ret, appchain)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernanceForbidden, appchain.Status)
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "GetServiceInfo", pb.String(chainServiceID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	err = json.Unmarshal(ret.Ret, service)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernancePause, service.Status)
+
+}
+
+func (suite *Service) TestLogoutService() {
+	path1 := "./test_data/config/node1/key.json"
+	path2 := "./test_data/config/node2/key.json"
+	path3 := "./test_data/config/node3/key.json"
+	keyPath1 := filepath.Join(path1)
+	keyPath2 := filepath.Join(path2)
+	keyPath3 := filepath.Join(path3)
+	priAdmin1, err := asym.RestorePrivateKey(keyPath1, "bitxhub")
+	suite.Require().Nil(err)
+	priAdmin2, err := asym.RestorePrivateKey(keyPath2, "bitxhub")
+	suite.Require().Nil(err)
+	priAdmin3, err := asym.RestorePrivateKey(keyPath3, "bitxhub")
+	suite.Require().Nil(err)
+	fromAdmin1, err := priAdmin1.PublicKey().Address()
+	suite.Require().Nil(err)
+	fromAdmin2, err := priAdmin2.PublicKey().Address()
+	suite.Require().Nil(err)
+	fromAdmin3, err := priAdmin3.PublicKey().Address()
+	suite.Require().Nil(err)
+	adminNonce1 := suite.api.Broker().GetPendingNonceByAccount(fromAdmin1.String())
+	adminNonce2 := suite.api.Broker().GetPendingNonceByAccount(fromAdmin2.String())
+	adminNonce3 := suite.api.Broker().GetPendingNonceByAccount(fromAdmin3.String())
+
+	k1, err := asym.GenerateKeyPair(crypto.Secp256k1)
+	suite.Require().Nil(err)
+	k2, err := asym.GenerateKeyPair(crypto.Secp256k1)
+	suite.Require().Nil(err)
+	suite.Require().Nil(err)
+	addr1, err := k1.PublicKey().Address()
+	suite.Require().Nil(err)
+	addr2, err := k2.PublicKey().Address()
+	suite.Require().Nil(err)
+	suite.Require().Nil(transfer(suite.Suite, suite.api, addr1, 10000000000000))
+	suite.Require().Nil(transfer(suite.Suite, suite.api, addr2, 10000000000000))
+	k1Nonce := suite.api.Broker().GetPendingNonceByAccount(addr1.String())
+
+	chainID1 := fmt.Sprintf("appchain%s", addr1.String())
+	serviceID1 := "service1"
+	chainServiceID1 := fmt.Sprintf("%s:%s", chainID1, serviceID1)
+
+	ret, err := invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "RegisterAppchain",
+		pb.String(chainID1),
+		pb.Bytes(nil),
+		pb.String("broker"),
+		pb.String("desc"),
+		pb.String(validator.FabricRuleAddr),
+		pb.String("reason"),
+	)
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	gRet := &governance.GovernanceResult{}
+	err = json.Unmarshal(ret.Ret, gRet)
+	suite.Require().Nil(err)
+	proposalRegisterAppchainId := gRet.ProposalID
+
+	suite.vote(proposalRegisterAppchainId, priAdmin1, adminNonce1, string(contracts.APPOVED))
+	adminNonce1++
+
+	suite.vote(proposalRegisterAppchainId, priAdmin2, adminNonce2, string(contracts.APPOVED))
+	adminNonce2++
+
+	suite.vote(proposalRegisterAppchainId, priAdmin3, adminNonce3, string(contracts.APPOVED))
+	adminNonce3++
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "GetAppchain", pb.String(chainID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	appchain := &appchainMgr.Appchain{}
+	err = json.Unmarshal(ret.Ret, appchain)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernanceAvailable, appchain.Status)
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "RegisterService",
+		pb.String(chainID1),
+		pb.String(serviceID1),
+		pb.String("name"),
+		pb.String(string(service_mgr.ServiceCallContract)),
+		pb.String("intro"),
+		pb.Bool(true),
+		pb.String(""),
+		pb.String("details"),
+		pb.String("raeson"),
+	)
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	gRet = &governance.GovernanceResult{}
+	err = json.Unmarshal(ret.Ret, gRet)
+	suite.Require().Nil(err)
+	proposalServiceId := gRet.ProposalID
+
+	suite.vote(proposalServiceId, priAdmin1, adminNonce1, string(contracts.APPOVED))
+	adminNonce1++
+
+	suite.vote(proposalServiceId, priAdmin2, adminNonce2, string(contracts.APPOVED))
+	adminNonce2++
+
+	suite.vote(proposalServiceId, priAdmin3, adminNonce3, string(contracts.APPOVED))
+	adminNonce3++
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "GetServiceInfo", pb.String(chainServiceID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	service := &service_mgr.Service{}
+	err = json.Unmarshal(ret.Ret, service)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernanceAvailable, service.Status)
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "LogoutService",
+		pb.String(chainServiceID1),
+		pb.String("raeson"),
+	)
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	gRet = &governance.GovernanceResult{}
+	err = json.Unmarshal(ret.Ret, gRet)
+	suite.Require().Nil(err)
+	proposalLogoutServiceID := gRet.ProposalID
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "LogoutAppchain",
+		pb.String(chainID1),
+		pb.String("raeson"),
+	)
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	gRet = &governance.GovernanceResult{}
+	err = json.Unmarshal(ret.Ret, gRet)
+	suite.Require().Nil(err)
+	proposalLogoutAppchainID := gRet.ProposalID
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "GetServiceInfo", pb.String(chainServiceID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	err = json.Unmarshal(ret.Ret, service)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernanceLogouting, service.Status)
+
+	suite.vote(proposalLogoutAppchainID, priAdmin1, adminNonce1, string(contracts.APPOVED))
+	adminNonce1++
+
+	suite.vote(proposalLogoutAppchainID, priAdmin2, adminNonce2, string(contracts.APPOVED))
+	adminNonce2++
+
+	suite.vote(proposalLogoutAppchainID, priAdmin3, adminNonce3, string(contracts.APPOVED))
+	adminNonce3++
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.AppchainMgrContractAddr.Address(), "GetAppchain", pb.String(chainID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	err = json.Unmarshal(ret.Ret, appchain)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernanceForbidden, appchain.Status)
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "GetServiceInfo", pb.String(chainServiceID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	err = json.Unmarshal(ret.Ret, service)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernanceLogouting, service.Status)
+
+	suite.vote(proposalLogoutServiceID, priAdmin1, adminNonce1, string(contracts.REJECTED))
+	adminNonce1++
+
+	suite.vote(proposalLogoutServiceID, priAdmin2, adminNonce2, string(contracts.REJECTED))
+	adminNonce2++
+
+	suite.vote(proposalLogoutServiceID, priAdmin3, adminNonce3, string(contracts.REJECTED))
+	adminNonce3++
+
+	ret, err = invokeBVMContract(suite.api, k1, k1Nonce, constant.ServiceMgrContractAddr.Address(), "GetServiceInfo", pb.String(chainServiceID1))
+	suite.Require().Nil(err)
+	suite.Require().True(ret.IsSuccess(), string(ret.Ret))
+	k1Nonce++
+	err = json.Unmarshal(ret.Ret, service)
+	suite.Require().Nil(err)
+	suite.Equal(governance.GovernancePause, service.Status)
+}
+
+func (suite *Service) vote(proposalId string, adminKey crypto.PrivateKey, adminNonce uint64, info string) {
 	ret, err := invokeBVMContract(suite.api, adminKey, adminNonce, constant.GovernanceContractAddr.Address(), "Vote",
 		pb.String(proposalId),
-		pb.String(string(contracts.APPOVED)),
+		pb.String(info),
 		pb.String("reason"),
 	)
 	suite.Require().Nil(err)


### PR DESCRIPTION
1. The appchain is unavailable in the logouting state. Therefore, it need to pause the service and unpause service when logouting fails;
2. If the service logout fails, check whether the appchain is available. If the appchain is unavailable, freeze the service.