### PR TITLE
fix(contracts): fix update service return is not a getGovernanceRet

### DIFF
--- a/internal/executor/contracts/service_manager.go
+++ b/internal/executor/contracts/service_manager.go
@@ -217,7 +217,7 @@ func (sm *ServiceManager) UpdateService(chainServiceID, name, intro string, orde
 		if !ok {
 			return boltvm.Error(fmt.Sprintf("update service error: %s", string(data)))
 		}
-		return boltvm.Success(nil)
+		return getGovernanceRet("", nil)
 	}
 
 	// 5. submit proposal


### PR DESCRIPTION
Governance methods are generally returned to a specified format for easy processing