### PR TITLE
fix(*): fix the node management bug

### DIFF
--- a/cmd/bitxhub/client/node_manage.go
+++ b/cmd/bitxhub/client/node_manage.go
@@ -130,7 +130,7 @@ func nodeMgrCMD() cli.Command {
 func getNodeStatusByAccount(ctx *cli.Context) error {
 	account := ctx.String("account")
 
-	receipt, err := invokeBVMContractBySendView(ctx, constant.NodeManagerContractAddr.String(), "GetNode", pb.String(account))
+	receipt, err := invokeBVMContractBySendView(ctx, constant.NodeManagerContractAddr.Address().String(), "GetNode", pb.String(account))
 	if err != nil {
 		return fmt.Errorf("invoke BVM contract failed when get node status by account %s: %w", account, err)
 	}
@@ -156,7 +156,7 @@ func registerNode(ctx *cli.Context) error {
 	permisssion := ctx.String("permission")
 	reason := ctx.String("reason")
 
-	receipt, err := invokeBVMContract(ctx, constant.NodeManagerContractAddr.String(), "RegisterNode",
+	receipt, err := invokeBVMContract(ctx, constant.NodeManagerContractAddr.Address().String(), "RegisterNode",
 		pb.String(account),
 		pb.String(typ),
 		pb.String(pid),
@@ -184,7 +184,7 @@ func updateNode(ctx *cli.Context) error {
 	permisssion := ctx.String("permission")
 	reason := ctx.String("reason")
 
-	receipt, err := invokeBVMContract(ctx, constant.NodeManagerContractAddr.String(), "UpdateNode",
+	receipt, err := invokeBVMContract(ctx, constant.NodeManagerContractAddr.Address().String(), "UpdateNode",
 		pb.String(account),
 		pb.String(name),
 		pb.String(permisssion),
@@ -207,7 +207,7 @@ func logoutNode(ctx *cli.Context) error {
 	account := ctx.String("account")
 	reason := ctx.String("reason")
 
-	receipt, err := invokeBVMContract(ctx, constant.NodeManagerContractAddr.String(), "LogoutNode", pb.String(account), pb.String(reason))
+	receipt, err := invokeBVMContract(ctx, constant.NodeManagerContractAddr.Address().String(), "LogoutNode", pb.String(account), pb.String(reason))
 	if err != nil {
 		return fmt.Errorf("invoke BVM contract failed when logout node by account %s for %s: %w", account, reason, err)
 	}
@@ -222,7 +222,7 @@ func logoutNode(ctx *cli.Context) error {
 }
 
 func allNode(ctx *cli.Context) error {
-	receipt, err := invokeBVMContractBySendView(ctx, constant.NodeManagerContractAddr.String(), "Nodes")
+	receipt, err := invokeBVMContractBySendView(ctx, constant.NodeManagerContractAddr.Address().String(), "Nodes")
 	if err != nil {
 		return fmt.Errorf("invoke BVM contract failed when get all node info: %w", err)
 	}

--- a/cmd/bitxhub/client/role_manage.go
+++ b/cmd/bitxhub/client/role_manage.go
@@ -150,7 +150,7 @@ func roleMgrCMD() cli.Command {
 func getRoleStatusById(ctx *cli.Context) error {
 	id := ctx.String("id")
 
-	receipt, err := invokeBVMContractBySendView(ctx, constant.RoleContractAddr.String(), "GetRoleInfoById", pb.String(id))
+	receipt, err := invokeBVMContractBySendView(ctx, constant.RoleContractAddr.Address().String(), "GetRoleInfoById", pb.String(id))
 	if err != nil {
 		return fmt.Errorf("invoke BVM contract failed when get role info by ID %s: %w", id, err)
 	}
@@ -173,7 +173,7 @@ func registerRole(ctx *cli.Context) error {
 	nodeAccount := ctx.String("nodeAccount")
 	reason := ctx.String("reason")
 
-	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.String(), "RegisterRole", pb.String(addr), pb.String(typ), pb.String(nodeAccount), pb.String(reason))
+	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.Address().String(), "RegisterRole", pb.String(addr), pb.String(typ), pb.String(nodeAccount), pb.String(reason))
 	if err != nil {
 		return fmt.Errorf("invoke BVM contract failed when register role \" addr=%s,typ=%s,nodeAccount=%s,reason=%s \": %w",
 			addr, typ, nodeAccount, reason, err)
@@ -193,7 +193,7 @@ func updateRole(ctx *cli.Context) error {
 	nodePid := ctx.String("nodePid")
 	reason := ctx.String("reason")
 
-	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.String(), "UpdateAuditAdminNode", pb.String(id), pb.String(nodePid), pb.String(reason))
+	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.Address().String(), "UpdateAuditAdminNode", pb.String(id), pb.String(nodePid), pb.String(reason))
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func freezeRole(ctx *cli.Context) error {
 	id := ctx.String("id")
 	reason := ctx.String("reason")
 
-	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.String(), "FreezeRole", pb.String(id), pb.String(reason))
+	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.Address().String(), "FreezeRole", pb.String(id), pb.String(reason))
 	if err != nil {
 		return fmt.Errorf("invoke BVM contract failed when freeze role %s for %s: %w", id, reason, err)
 	}
@@ -229,7 +229,7 @@ func activateRole(ctx *cli.Context) error {
 	id := ctx.String("id")
 	reason := ctx.String("reason")
 
-	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.String(), "ActivateRole", pb.String(id), pb.String(reason))
+	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.Address().String(), "ActivateRole", pb.String(id), pb.String(reason))
 	if err != nil {
 		return fmt.Errorf("invoke BVM contract failed when activate role %s for %s: %w", id, reason, err)
 	}
@@ -247,7 +247,7 @@ func logoutRole(ctx *cli.Context) error {
 	id := ctx.String("id")
 	reason := ctx.String("reason")
 
-	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.String(), "LogoutRole", pb.String(id), pb.String(reason))
+	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.Address().String(), "LogoutRole", pb.String(id), pb.String(reason))
 	if err != nil {
 		return fmt.Errorf("invoke BVM contract failed when logout role %s for %s: %w", id, reason, err)
 	}
@@ -266,7 +266,7 @@ func bindRole(ctx *cli.Context) error {
 	account := ctx.String("account")
 	reason := ctx.String("reason")
 
-	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.String(), "BindRole", pb.String(id), pb.String(account), pb.String(reason))
+	receipt, err := invokeBVMContract(ctx, constant.RoleContractAddr.Address().String(), "BindRole", pb.String(id), pb.String(account), pb.String(reason))
 	if err != nil {
 		return fmt.Errorf("invoke BVM contract failed when bind role %s with node %s for %s: %w", id, account, reason, err)
 	}
@@ -286,13 +286,13 @@ func allRole(ctx *cli.Context) error {
 	var ret *pb.Receipt
 	switch typ {
 	case string(contracts.GovernanceAdmin):
-		receipt, err := invokeBVMContractBySendView(ctx, constant.RoleContractAddr.String(), "GetAllRoles")
+		receipt, err := invokeBVMContractBySendView(ctx, constant.RoleContractAddr.Address().String(), "GetAllRoles")
 		if err != nil {
 			return fmt.Errorf("invoke BVM contract failed when get all roles: %w", err)
 		}
 		ret = receipt
 	case string(contracts.AuditAdmin):
-		receipt, err := invokeBVMContractBySendView(ctx, constant.RoleContractAddr.String(), "GetAuditAdminRoles")
+		receipt, err := invokeBVMContractBySendView(ctx, constant.RoleContractAddr.Address().String(), "GetAuditAdminRoles")
 		if err != nil {
 			return fmt.Errorf("invoke BVM contract failed when get audit admin roles: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.5.6
 	github.com/looplab/fsm v0.2.0
 	github.com/magiconair/properties v1.8.4
-	github.com/meshplus/bitxhub-core v1.3.1-0.20211208022633-89e3333df71c
+	github.com/meshplus/bitxhub-core v1.3.1-0.20211210014317-f567bf2c0d6d
 	github.com/meshplus/bitxhub-kit v1.2.1-0.20211125010920-547e4651583e
 	github.com/meshplus/bitxhub-model v1.2.1-0.20211207095229-a43d4b219b66
 	github.com/meshplus/eth-kit v0.0.0-20210906064541-8dfea98dbf95

--- a/go.sum
+++ b/go.sum
@@ -747,8 +747,8 @@ github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsO
 github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4fJH25nqRHfWLMa1ONC8Amw+mIA639KxkE=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/meshplus/bitxhub-core v1.3.1-0.20211208022633-89e3333df71c h1:s4Z+7P171BJxjNzgzGEgRsaDrobGI+/Va8LYSiPbaYs=
-github.com/meshplus/bitxhub-core v1.3.1-0.20211208022633-89e3333df71c/go.mod h1:DdG+dfeNS57Wi+0bcDA4iel3sZgHNY9oDmNSDVj4ZME=
+github.com/meshplus/bitxhub-core v1.3.1-0.20211210014317-f567bf2c0d6d h1:WjwNaEtb5eLn0w1HutDCZB9LwXVbw4Ge333e9zNAEyg=
+github.com/meshplus/bitxhub-core v1.3.1-0.20211210014317-f567bf2c0d6d/go.mod h1:DdG+dfeNS57Wi+0bcDA4iel3sZgHNY9oDmNSDVj4ZME=
 github.com/meshplus/bitxhub-kit v1.1.1/go.mod h1:r4l4iqn0RPJreb/OmoYKfjCjQJrXpZX++6Qc31VG/1k=
 github.com/meshplus/bitxhub-kit v1.2.1-0.20210616114532-4849447f09e1/go.mod h1:wrEdhHp1tktzdwcWb4bOxYsVc+KkcrYL18IYWYeumPQ=
 github.com/meshplus/bitxhub-kit v1.2.1-0.20210902085548-07f4fa85bfc9/go.mod h1:wrEdhHp1tktzdwcWb4bOxYsVc+KkcrYL18IYWYeumPQ=

--- a/internal/executor/contracts/node_manager.go
+++ b/internal/executor/contracts/node_manager.go
@@ -44,7 +44,7 @@ func (nm *NodeManager) checkPermission(permissions []string, nodeAccount, regula
 				return nil
 			}
 		case string(PermissionAdmin):
-			res := nm.CrossInvoke(constant.RoleContractAddr.String(), "IsAnyAvailableAdmin",
+			res := nm.CrossInvoke(constant.RoleContractAddr.Address().String(), "IsAnyAvailableAdmin",
 				pb.String(regulatorAddr),
 				pb.String(string(GovernanceAdmin)))
 			if !res.Ok {
@@ -181,8 +181,10 @@ func (nm *NodeManager) Manage(eventTyp, proposalResult, lastStatus, objId string
 				}
 				nm.PostEvent(pb.Event_NODEMGR, nodeEvent)
 			case nodemgr.NVPNode:
-				if res := nm.CrossInvoke(constant.RoleContractAddr.Address().String(), "PauseAuditAdmin", pb.String(nodeInfo.AuditAdminAddr)); !res.Ok {
-					return boltvm.Error(boltvm.NodeInternalErrCode, fmt.Sprintf(string(boltvm.NodeInternalErrMsg), string(res.Result)))
+				if nodeInfo.AuditAdminAddr != "" {
+					if res := nm.CrossInvoke(constant.RoleContractAddr.Address().String(), "PauseAuditAdmin", pb.String(nodeInfo.AuditAdminAddr)); !res.Ok {
+						return boltvm.Error(boltvm.NodeInternalErrCode, fmt.Sprintf(string(boltvm.NodeInternalErrMsg), fmt.Sprintf("cross invoke PauseAuditAdmin error: %s", string(res.Result))))
+					}
 				}
 			}
 		}

--- a/internal/executor/contracts/node_manager_test.go
+++ b/internal/executor/contracts/node_manager_test.go
@@ -318,7 +318,8 @@ func TestNodeManager_Manage_NVPNode(t *testing.T) {
 	mockStub.EXPECT().GetObject(node_mgr.NodeKey(nodes[4].Account), gomock.Any()).SetArg(1, *nodes[4]).Return(true).AnyTimes()
 	mockStub.EXPECT().GetObject(node_mgr.NodeKey(nodes[5].Account), gomock.Any()).SetArg(1, *nodes[5]).Return(true).AnyTimes()
 	mockStub.EXPECT().GetObject(node_mgr.NodeKey(nodes[6].Account), gomock.Any()).SetArg(1, *nodes[6]).Return(true).AnyTimes()
-	mockStub.EXPECT().CrossInvoke(constant.RoleContractAddr.Address().String(), "PauseAuditAdmin", pb.String(nodes[6].AuditAdminAddr)).Return(boltvm.Error("", "PauseAuditAdmin error")).AnyTimes()
+	mockStub.EXPECT().GetObject(node_mgr.NodeKey(nodes[7].Account), gomock.Any()).SetArg(1, *nodes[7]).Return(true).AnyTimes()
+	mockStub.EXPECT().CrossInvoke(constant.RoleContractAddr.Address().String(), "PauseAuditAdmin", pb.String(nodes[7].AuditAdminAddr)).Return(boltvm.Error("", "PauseAuditAdmin error")).AnyTimes()
 	mockStub.EXPECT().CrossInvoke(constant.RoleContractAddr.Address().String(), "FreeAccount",
 		gomock.Any()).Return(boltvm.Success(nil)).AnyTimes()
 
@@ -350,6 +351,8 @@ func TestNodeManager_Manage_NVPNode(t *testing.T) {
 
 	// logout, approve
 	res = nm.Manage(string(governance.EventLogout), BallotApprove, string(governance.GovernanceAvailable), nodes[6].Account, nil)
+	assert.True(t, res.Ok, string(res.Result))
+	res = nm.Manage(string(governance.EventLogout), BallotApprove, string(governance.GovernanceAvailable), nodes[7].Account, nil)
 	assert.False(t, res.Ok, string(res.Result))
 }
 
@@ -537,8 +540,10 @@ func nvpNodePrepare(t *testing.T) (*NodeManager, *mock_stub.MockStub, []*node_mg
 		string(governance.GovernanceBinded),
 		string(governance.GovernanceRegisting),
 		string(governance.GovernanceUpdating),
-		string(governance.GovernanceLogouting)}
-	for i := 0; i < 7; i++ {
+		string(governance.GovernanceLogouting),
+		string(governance.GovernanceLogouting),
+	}
+	for i := 0; i < 8; i++ {
 		node := &node_mgr.Node{
 			Account: fmt.Sprintf("%s%d", NODE_ACCOUNT[0:len(NODE_ACCOUNT)-1], i),
 			Name:    fmt.Sprintf("%s%d", NODE_NAME, i),
@@ -547,6 +552,9 @@ func nvpNodePrepare(t *testing.T) (*NodeManager, *mock_stub.MockStub, []*node_mg
 			},
 			NodeType: node_mgr.NVPNode,
 			Status:   governance.GovernanceStatus(nvpNodeStatus[i]),
+		}
+		if i == 7 {
+			node.AuditAdminAddr = "111"
 		}
 
 		data, err := json.Marshal(node)


### PR DESCRIPTION
1. The audit admin is unbound from the audit node only after being logouted successfully;
2. If the audit admin fails to logout, it will be automatically suspended if the audit node becomes unavailable;
3. Fix the bug that panic occurs when bound audit node is logouted.

Bitxhub-core needs to be merged first: meshplus/bitxhub-core#137