### PR TITLE
fix(bvm): Optimize some redundant cross-contract calls and JSON parsing in interchain contract

### DIFF
--- a/internal/executor/contracts/appchain_manager.go
+++ b/internal/executor/contracts/appchain_manager.go
@@ -951,6 +951,20 @@ func (am *AppchainManager) IsAvailable(chainID string) *boltvm.Response {
 	return boltvm.Success([]byte(strconv.FormatBool(chain.(*appchainMgr.Appchain).IsAvailable())))
 }
 
+func (am *AppchainManager) IsAvailableBitxhub(chainID string) *boltvm.Response {
+	am.AppchainManager.Persister = am.Stub
+	chain, err := am.AppchainManager.QueryById(chainID, nil)
+	if err != nil {
+		return boltvm.Error(boltvm.AppchainNonexistentChainCode, fmt.Sprintf(string(boltvm.AppchainNonexistentChainMsg), chainID, err.Error()))
+	}
+
+	if chain.(*appchainMgr.Appchain).IsAvailable() && chain.(*appchainMgr.Appchain).IsBitXHub() {
+		return boltvm.Success([]byte(TRUE))
+	} else {
+		return boltvm.Success([]byte(FALSE))
+	}
+}
+
 func (am *AppchainManager) GetBitXHubChainIDs() *boltvm.Response {
 	am.AppchainManager.Persister = am.Stub
 	relayChainIdMap := orderedmap.New()

--- a/internal/executor/contracts/interchain.go
+++ b/internal/executor/contracts/interchain.go
@@ -32,20 +32,6 @@ const (
 	MULTITX_PREFIX             = "multitx"
 )
 
-type InterchainMeta struct {
-	TargetChain string `json:"target_chain"`
-	TxHash      string `json:"tx_hash"`
-	Timestamp   int64  `json:"timestamp"`
-}
-
-type InterchainInfo struct {
-	ChainId            string            `json:"chain_id"`
-	InterchainCounter  uint64            `json:"interchain_counter"`
-	ReceiptCounter     uint64            `json:"receipt_counter"`
-	SendInterchains    []*InterchainMeta `json:"send_interchains"`
-	ReceiptInterchains []*InterchainMeta `json:"receipt_interchains"`
-}
-
 type InterchainManager struct {
 	boltvm.Stub
 }
@@ -99,38 +85,6 @@ func (x *InterchainManager) DeleteInterchain(id string) *boltvm.Response {
 		return boltvm.Error(boltvm.InterchainInternalErrCode, fmt.Sprintf(string(boltvm.InterchainInternalErrMsg), fmt.Sprintf("post audit interchain event error: %v", err)))
 	}
 	return boltvm.Success(nil)
-}
-
-// todo: the parameter name should be fullServiceID
-func (x *InterchainManager) GetInterchainInfo(chainId string) *boltvm.Response {
-	interchain, ok := x.getInterchain(chainId)
-	info := &InterchainInfo{
-		ChainId:            chainId,
-		SendInterchains:    []*InterchainMeta{},
-		ReceiptInterchains: []*InterchainMeta{},
-	}
-	if !ok {
-		interchain = &pb.Interchain{
-			ID:                   chainId,
-			InterchainCounter:    make(map[string]uint64),
-			ReceiptCounter:       make(map[string]uint64),
-			SourceReceiptCounter: make(map[string]uint64),
-		}
-	}
-	for _, counter := range interchain.InterchainCounter {
-		info.InterchainCounter += counter
-	}
-
-	for _, counter := range interchain.ReceiptCounter {
-		info.ReceiptCounter += counter
-	}
-	x.GetObject(x.indexSendInterchainMeta(chainId), &info.SendInterchains)
-	x.GetObject(x.indexReceiptInterchainMeta(chainId), &info.ReceiptInterchains)
-	data, err := json.Marshal(&info)
-	if err != nil {
-		return boltvm.Error(boltvm.InterchainInternalErrCode, fmt.Sprintf(string(boltvm.InterchainInternalErrMsg), err.Error()))
-	}
-	return boltvm.Success(data)
 }
 
 // getInterchain returns information of the interchain count, Receipt count and SourceReceipt count by id
@@ -245,11 +199,17 @@ func (x *InterchainManager) checkIBTP(ibtp *pb.IBTP) (*pb.Interchain, *boltvm.Bx
 				return nil, nil, err
 			}
 
-			targetError = x.checkTargetAvailability(srcChainService, dstChainService, ibtp.Type)
+			// Ordered identifies whether the dst service needs to be invoked sequentially, that is, check index
+			// - Large-scale cross-chain services: not local
+			// - Services that are registered on the bitxhub and need to be called in order: is local && ordered == true
+			// - Bitxhub service: is local && ChainId == BxhId
+			var ordered bool
+			ordered, targetError = x.checkTargetAvailability(srcChainService, dstChainService, ibtp.Type)
 
-			// if dst chain service is from appchain registered in current bitxhub, get service info and check index
-			if err := x.checkServiceIndex(ibtp, interchain.InterchainCounter, dstChainService); err != nil {
-				return nil, nil, err
+			if ordered {
+				if err := checkIndex(interchain.InterchainCounter[dstChainService.getFullServiceId()]+1, ibtp.Index); err != nil {
+					return nil, nil, err
+				}
 			}
 		} else {
 			if !dstChainService.IsLocal {
@@ -260,13 +220,24 @@ func (x *InterchainManager) checkIBTP(ibtp *pb.IBTP) (*pb.Interchain, *boltvm.Bx
 				return nil, nil, boltvm.BError(boltvm.InterchainSourceBitXHubNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainSourceBitXHubNotAvailableMsg), srcChainService.BxhId, err))
 			}
 
-			if err := x.checkServiceIndex(ibtp, interchain.InterchainCounter, dstChainService); err != nil {
-				return nil, nil, err
+			var ordered bool
+			ordered, targetError = x.checkTargetAvailability(srcChainService, dstChainService, ibtp.Type)
+
+			if ordered {
+				if err := checkIndex(interchain.InterchainCounter[dstChainService.getFullServiceId()]+1, ibtp.Index); err != nil {
+					return nil, nil, err
+				}
 			}
 		}
 	} else if ibtp.Category() == pb.IBTP_RESPONSE {
-		if err := x.checkServiceIndex(ibtp, interchain.ReceiptCounter, dstChainService); err != nil {
-			return nil, nil, err
+		// Situation which need to check the index
+		// - Bitxhub service：dstService == nil
+		// - The dst service needs to be invoked sequentially：dstService.Ordered
+		dstService, _ := x.getServiceByID(dstChainService.getChainServiceId())
+		if dstService == nil || dstService.Ordered {
+			if err := checkIndex(interchain.InterchainCounter[dstChainService.getFullServiceId()]+1, ibtp.Index); err != nil {
+				return nil, nil, err
+			}
 		}
 	} else {
 		return nil, nil, boltvm.BError(boltvm.InterchainInvalidIBTPIllegalTypeCode, fmt.Sprintf(string(boltvm.InterchainInvalidIBTPIllegalTypeMsg), ibtp.Type))
@@ -276,9 +247,9 @@ func (x *InterchainManager) checkIBTP(ibtp *pb.IBTP) (*pb.Interchain, *boltvm.Bx
 }
 
 func (x *InterchainManager) checkSourceAvailability(srcChainService *ChainService) *boltvm.BxhError {
-	if err := x.checkAppchainAvailability(srcChainService.ChainId); err != nil {
-		return boltvm.BError(boltvm.InterchainSourceAppchainNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainSourceAppchainNotAvailableMsg), srcChainService.ChainId, err.Error()))
-	}
+	//if err := x.checkAppchainAvailability(srcChainService.ChainId); err != nil {
+	//	return boltvm.BError(boltvm.InterchainSourceAppchainNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainSourceAppchainNotAvailableMsg), srcChainService.ChainId, err.Error()))
+	//}
 
 	if err := x.checkServiceAvailability(srcChainService.getChainServiceId()); err != nil {
 		return boltvm.BError(boltvm.InterchainSourceServiceNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainSourceServiceNotAvailableMsg), srcChainService.getChainServiceId(), err.Error()))
@@ -287,37 +258,40 @@ func (x *InterchainManager) checkSourceAvailability(srcChainService *ChainServic
 	return nil
 }
 
-func (x *InterchainManager) checkTargetAvailability(srcChainService, dstChainService *ChainService, typ pb.IBTP_Type) *boltvm.BxhError {
+// The first return value indicates whether the destination service needs to be invoked in order, that is, whether index needs to be checked
+func (x *InterchainManager) checkTargetAvailability(srcChainService, dstChainService *ChainService, typ pb.IBTP_Type) (bool, *boltvm.BxhError) {
+	ordered := true
 	if pb.IBTP_INTERCHAIN == typ {
 		if dstChainService.IsLocal {
 			if dstChainService.ChainId == dstChainService.BxhId {
-				return nil
+				return true, nil
 			}
 
-			if err := x.checkAppchainAvailability(dstChainService.ChainId); err != nil {
-				return boltvm.BError(boltvm.InterchainTargetAppchainNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainTargetAppchainNotAvailableMsg), dstChainService.ChainId, err.Error()))
-			}
+			//if err := x.checkAppchainAvailability(dstChainService.ChainId); err != nil {
+			//	return boltvm.BError(boltvm.InterchainTargetAppchainNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainTargetAppchainNotAvailableMsg), dstChainService.ChainId, err.Error()))
+			//}
 
 			dstService, err := x.getServiceByID(dstChainService.getChainServiceId())
 			if err != nil {
-				return boltvm.BError(boltvm.InterchainTargetServiceNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainTargetServiceNotAvailableMsg), dstChainService.getChainServiceId(), err.Error()))
+				return true, boltvm.BError(boltvm.InterchainTargetServiceNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainTargetServiceNotAvailableMsg), dstChainService.getChainServiceId(), err.Error()))
 			}
+			ordered = dstService.Ordered
 
 			if !dstService.IsAvailable() {
-				return boltvm.BError(boltvm.InterchainTargetServiceNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainTargetServiceNotAvailableMsg), dstChainService.getChainServiceId(), fmt.Sprintf("current status of service %s is %v", dstChainService.getChainServiceId(), dstService.Status)))
+				return ordered, boltvm.BError(boltvm.InterchainTargetServiceNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainTargetServiceNotAvailableMsg), dstChainService.getChainServiceId(), fmt.Sprintf("current status of service %s is %v", dstChainService.getChainServiceId(), dstService.Status)))
 			}
 
 			if !dstService.CheckPermission(srcChainService.getFullServiceId()) {
-				return boltvm.BError(boltvm.InterchainTargetServiceNoPermissionCode, fmt.Sprintf(string(boltvm.InterchainTargetServiceNoPermissionMsg), srcChainService.getFullServiceId(), dstChainService.getFullServiceId()))
+				return ordered, boltvm.BError(boltvm.InterchainTargetServiceNoPermissionCode, fmt.Sprintf(string(boltvm.InterchainTargetServiceNoPermissionMsg), srcChainService.getFullServiceId(), dstChainService.getFullServiceId()))
 			}
 		} else {
 			if err := x.checkBitXHubAvailability(dstChainService.BxhId); err != nil {
-				return boltvm.BError(boltvm.InterchainTargetBitXHubNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainTargetBitXHubNotAvailableMsg), dstChainService.BxhId, err))
+				return ordered, boltvm.BError(boltvm.InterchainTargetBitXHubNotAvailableCode, fmt.Sprintf(string(boltvm.InterchainTargetBitXHubNotAvailableMsg), dstChainService.BxhId, err))
 			}
 		}
 	}
 
-	return nil
+	return ordered, nil
 }
 
 // getAppchainInfo returns the appchain info by chain ID
@@ -356,7 +330,6 @@ func (x *InterchainManager) ProcessIBTP(ibtp *pb.IBTP, interchain *pb.Interchain
 		ic, _ := x.getInterchain(ibtp.To)
 		ic.SourceInterchainCounter[ibtp.From] = ibtp.Index
 		x.setInterchain(ibtp.To, ic)
-		x.updateInterchainMeta(ibtp)
 	} else {
 		interchain.ReceiptCounter[ibtp.To] = ibtp.Index
 		x.setInterchain(ibtp.From, interchain)
@@ -381,18 +354,6 @@ func (x *InterchainManager) ProcessIBTP(ibtp *pb.IBTP, interchain *pb.Interchain
 	}
 
 	return nil
-}
-
-func (x *InterchainManager) updateInterchainMeta(ibtp *pb.IBTP) {
-	meta := &InterchainMeta{
-		TargetChain: ibtp.To,
-		TxHash:      x.GetTxHash().String(),
-		Timestamp:   x.GetTxTimeStamp(),
-	}
-	x.setInterchainMeta(x.indexSendInterchainMeta(ibtp.From), meta)
-
-	meta.TargetChain = ibtp.From
-	x.setInterchainMeta(x.indexReceiptInterchainMeta(ibtp.To), meta)
 }
 
 func (x *InterchainManager) notifySrcDst(ibtp *pb.IBTP, statusChange *StatusChange) {
@@ -593,12 +554,8 @@ func (x *InterchainManager) getServiceByID(id string) (*service_mgr.Service, err
 }
 
 func (x *InterchainManager) checkAppchainAvailability(id string) error {
-	chain, err := x.getAppchainInfo(id)
-	if err != nil {
-		return err
-	}
-
-	if !chain.IsAvailable() {
+	res := x.CrossInvoke(constant.AppchainMgrContractAddr.Address().String(), "IsAvailable", pb.String(id))
+	if !res.Ok || string(res.Result) == FALSE {
 		return fmt.Errorf("appchain %s is not available", id)
 	}
 
@@ -606,29 +563,17 @@ func (x *InterchainManager) checkAppchainAvailability(id string) error {
 }
 
 func (x *InterchainManager) checkBitXHubAvailability(id string) error {
-	chain, err := x.getAppchainInfo(id)
-	if err != nil {
-		return err
-	}
-
-	if !chain.IsBitXHub() {
-		return fmt.Errorf("chain %s is not BitXHub", id)
-	}
-
-	if !chain.IsAvailable() {
-		return fmt.Errorf("bitxhub %s is not available", id)
+	res := x.CrossInvoke(constant.AppchainMgrContractAddr.Address().String(), "IsAvailableBitxhub", pb.String(id))
+	if !res.Ok || string(res.Result) == FALSE {
+		return fmt.Errorf("chain %s is not available bitxhub", id)
 	}
 
 	return nil
 }
 
 func (x *InterchainManager) checkServiceAvailability(chainServiceID string) error {
-	service, err := x.getServiceByID(chainServiceID)
-	if err != nil {
-		return fmt.Errorf("cannot get service by %s", chainServiceID)
-	}
-
-	if !service.IsAvailable() {
+	res := x.CrossInvoke(constant.ServiceMgrContractAddr.Address().String(), "IsAvailable", pb.String(chainServiceID))
+	if !res.Ok || string(res.Result) == FALSE {
 		return fmt.Errorf("service %s is not available", chainServiceID)
 	}
 
@@ -687,24 +632,6 @@ func (x *InterchainManager) addToMultiTxNotifyMap(height uint64, ibtpIDs []strin
 	}
 
 	x.SetObject(MultiTxNotifyKey(height), multiTxNotifyMap)
-}
-
-func (x *InterchainManager) setInterchainMeta(indexKey string, meta *InterchainMeta) {
-	var metas []*InterchainMeta
-	x.GetObject(indexKey, &metas)
-	if len(metas) >= 5 {
-		metas = metas[1:]
-	}
-	metas = append(metas, meta)
-	x.SetObject(indexKey, &metas)
-}
-
-func (x *InterchainManager) indexSendInterchainMeta(id string) string {
-	return fmt.Sprintf("index-send-interchain-%s", id)
-}
-
-func (x *InterchainManager) indexReceiptInterchainMeta(id string) string {
-	return fmt.Sprintf("index-receipt-interchain-%s", id)
 }
 
 func serviceKey(id string) string {

--- a/internal/executor/contracts/interchain_test.go
+++ b/internal/executor/contracts/interchain_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	appchainMgr "github.com/meshplus/bitxhub-core/appchain-mgr"
 	"github.com/meshplus/bitxhub-core/boltvm"
 	"github.com/meshplus/bitxhub-core/boltvm/mock_stub"
 	"github.com/meshplus/bitxhub-core/governance"
@@ -124,21 +123,21 @@ func TestInterchainManager_GetInterchain(t *testing.T) {
 
 func TestInterchainManager_HandleIBTP(t *testing.T) {
 	srcChainService, dstChainService := mockChainService()
-	unavailableChainID := "appchain3"
-	unexistChainID := "appchain4"
-	unexistChainServiceID := fmt.Sprintf("bxh:%s:service", unexistChainID)
-	unavailableChainServiceID := fmt.Sprintf("bxh:%s:service", unavailableChainID)
+	//unavailableChainID := "appchain3"
+	//unexistChainID := "appchain4"
+	//unexistChainServiceID := fmt.Sprintf("bxh:%s:service", unexistChainID)
+	//unavailableChainServiceID := fmt.Sprintf("bxh:%s:service", unavailableChainID)
 
 	unexistServiceID := "service3"
 	unexistServiceChainServiceID := fmt.Sprintf("%s:%s", srcChainID, unexistServiceID)
-	unexistServiceServiceID := fmt.Sprintf("bxh:%s", unexistServiceChainServiceID)
+	unexistServiceFullServiceID := fmt.Sprintf("bxh:%s", unexistServiceChainServiceID)
 
 	unavailableServiceID := "service4"
 	unavailableServiceChainServiceID := fmt.Sprintf("%s:%s", srcChainID, unavailableServiceID)
-	unavailableServiceServiceID := fmt.Sprintf("bxh:%s", unavailableServiceChainServiceID)
+	unavailableServiceFullServiceID := fmt.Sprintf("bxh:%s", unavailableServiceChainServiceID)
 
 	unavailableDstServiceChainServiceID := fmt.Sprintf("%s:%s", dstChainID, unavailableServiceID)
-	unavailableDstServiceServiceID := fmt.Sprintf("bxh:%s", unavailableDstServiceChainServiceID)
+	unavailableDstServiceFullServiceID := fmt.Sprintf("bxh:%s", unavailableDstServiceChainServiceID)
 
 	unPermissionServiceID := "service5"
 	unPermissionServiceChainServiceID := fmt.Sprintf("%s:%s", dstChainID, unPermissionServiceID)
@@ -193,52 +192,54 @@ func TestInterchainManager_HandleIBTP(t *testing.T) {
 		return false, nil
 	}).AnyTimes()
 
-	appchain := &appchainMgr.Appchain{
-		ID:      srcChainID,
-		Status:  governance.GovernanceAvailable,
-		Desc:    "Relay1",
-		Version: 0,
-	}
-	appchainData, err := json.Marshal(appchain)
-	require.Nil(t, err)
+	//appchain := &appchainMgr.Appchain{
+	//	ID:      srcChainID,
+	//	Status:  governance.GovernanceAvailable,
+	//	Desc:    "Relay1",
+	//	Version: 0,
+	//}
+	//appchainData, err := json.Marshal(appchain)
+	//require.Nil(t, err)
+	//
+	//dstAppchain := &appchainMgr.Appchain{
+	//	ID:      dstChainID,
+	//	Status:  governance.GovernanceAvailable,
+	//	Desc:    "Relay2",
+	//	Version: 0,
+	//}
+	//dstAppchainData, err := json.Marshal(dstAppchain)
+	//assert.Nil(t, err)
 
-	dstAppchain := &appchainMgr.Appchain{
-		ID:      dstChainID,
-		Status:  governance.GovernanceAvailable,
-		Desc:    "Relay2",
-		Version: 0,
-	}
-	dstAppchainData, err := json.Marshal(dstAppchain)
-	assert.Nil(t, err)
+	//unavailableChain := &appchainMgr.Appchain{
+	//	ID:      unavailableChainID,
+	//	Status:  governance.GovernanceFrozen,
+	//	Desc:    "Relay1",
+	//	Version: 0,
+	//}
+	//unavailableChainData, err := json.Marshal(unavailableChain)
+	//require.Nil(t, err)
 
-	unavailableChain := &appchainMgr.Appchain{
-		ID:      unavailableChainID,
-		Status:  governance.GovernanceFrozen,
-		Desc:    "Relay1",
-		Version: 0,
-	}
-	unavailableChainData, err := json.Marshal(unavailableChain)
-	require.Nil(t, err)
-
-	wrongBitxhubChain := &appchainMgr.Appchain{
-		ID:     wrongBitxhubID,
-		Status: governance.GovernanceAvailable,
-		Broker: []byte("broker"),
-	}
-	wrongBitxhubChainData, err := json.Marshal(wrongBitxhubChain)
-	require.Nil(t, err)
-
-	unavailableBitxhubChain := &appchainMgr.Appchain{
-		ID:     unavailableBitxhubID,
-		Status: governance.GovernanceUnavailable,
-		Broker: []byte(constant.InterBrokerContractAddr.Address().String()),
-	}
-	unavailableBitxhubChainData, err := json.Marshal(unavailableBitxhubChain)
-	require.Nil(t, err)
+	//wrongBitxhubChain := &appchainMgr.Appchain{
+	//	ID:     wrongBitxhubID,
+	//	Status: governance.GovernanceAvailable,
+	//	Broker: []byte("broker"),
+	//}
+	//wrongBitxhubChainData, err := json.Marshal(wrongBitxhubChain)
+	//require.Nil(t, err)
+	//
+	//unavailableBitxhubChain := &appchainMgr.Appchain{
+	//	ID:     unavailableBitxhubID,
+	//	Status: governance.GovernanceUnavailable,
+	//	Broker: []byte(constant.InterBrokerContractAddr.Address().String()),
+	//}
+	//unavailableBitxhubChainData, err := json.Marshal(unavailableBitxhubChain)
+	//require.Nil(t, err)
 
 	unavailableService := &service_mgr.Service{
-		ServiceID: unavailableChainServiceID,
+		ServiceID: unavailableServiceChainServiceID,
+		ChainID:   srcChainID,
 		Status:    governance.GovernanceUnavailable,
+		Ordered:   true,
 	}
 	unavailableServiceData, err := json.Marshal(unavailableService)
 	require.Nil(t, err)
@@ -271,22 +272,44 @@ func TestInterchainManager_HandleIBTP(t *testing.T) {
 	unPermissionServiceData, err := json.Marshal(unPermissionService)
 	require.Nil(t, err)
 
+	//mockStub.EXPECT().CrossInvoke(constant.AppchainMgrContractAddr.Address().String(), gomock.Any(), gomock.Any()).DoAndReturn(
+	//	func(addr string, method string, args ...*pb.Arg) *boltvm.Response {
+	//		if method == "IsAvailable" {
+	//			switch string(args[0].GetValue()) {
+	//			case srcChainID:
+	//				return boltvm.Success([]byte(TRUE))
+	//			//case dstChainID:
+	//			//	return boltvm.Success([]byte(TRUE))
+	//			case unexistChainID:
+	//				return boltvm.Error("", "")
+	//			case unavailableChainID:
+	//				return boltvm.Success([]byte(FALSE))
+	//				//case wrongBitxhubID:
+	//				//	return boltvm.Success(wrongBitxhubChainData)
+	//				//case unavailableBitxhubID:
+	//				//	return boltvm.Success(unavailableBitxhubChainData)
+	//			}
+	//		}
+	//
+	//		return boltvm.Error("", "")
+	//	}).AnyTimes()
+
 	mockStub.EXPECT().CrossInvoke(constant.AppchainMgrContractAddr.Address().String(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(addr string, method string, args ...*pb.Arg) *boltvm.Response {
-			if method == "GetAppchain" {
+			if method == "IsAvailableBitxhub" {
 				switch string(args[0].GetValue()) {
-				case srcChainID:
-					return boltvm.Success(appchainData)
-				case dstChainID:
-					return boltvm.Success(dstAppchainData)
-				case unexistChainID:
-					return boltvm.Error("", "")
-				case unavailableChainID:
-					return boltvm.Success(unavailableChainData)
+				//case srcChainID:
+				//	return boltvm.Success([]byte(TRUE))
+				//case dstChainID:
+				//	return boltvm.Success([]byte(TRUE))
+				//case unexistChainID:
+				//	return boltvm.Error("", "")
+				//case unavailableChainID:
+				//	return boltvm.Success([]byte(FALSE))
 				case wrongBitxhubID:
-					return boltvm.Success(wrongBitxhubChainData)
+					return boltvm.Success([]byte(FALSE))
 				case unavailableBitxhubID:
-					return boltvm.Success(unavailableBitxhubChainData)
+					return boltvm.Success([]byte(FALSE))
 				}
 			}
 
@@ -300,7 +323,7 @@ func TestInterchainManager_HandleIBTP(t *testing.T) {
 				return boltvm.Error("", "")
 			case unavailableServiceChainServiceID:
 				return boltvm.Success(unavailableServiceData)
-			case unavailableDstServiceServiceID:
+			case unavailableDstServiceChainServiceID:
 				return boltvm.Success(unavailableServiceData)
 			case srcChainService.getChainServiceId():
 				return boltvm.Success(srcServiceData)
@@ -308,6 +331,26 @@ func TestInterchainManager_HandleIBTP(t *testing.T) {
 				return boltvm.Success(dstServiceData)
 			case unPermissionServiceChainServiceID:
 				return boltvm.Success(unPermissionServiceData)
+			}
+
+			return boltvm.Error("", "")
+		}).AnyTimes()
+
+	mockStub.EXPECT().CrossInvoke(constant.ServiceMgrContractAddr.Address().String(), "IsAvailable", gomock.Any()).DoAndReturn(
+		func(addr string, method string, args ...*pb.Arg) *boltvm.Response {
+			switch string(args[0].GetValue()) {
+			case unexistServiceChainServiceID:
+				return boltvm.Error("", "")
+			case unavailableServiceChainServiceID:
+				return boltvm.Success([]byte(FALSE))
+			case unavailableDstServiceChainServiceID:
+				return boltvm.Success([]byte(FALSE))
+			case srcChainService.getChainServiceId():
+				return boltvm.Success([]byte(TRUE))
+			case dstChainService.getChainServiceId():
+				return boltvm.Success([]byte(TRUE))
+			case unPermissionServiceChainServiceID:
+				return boltvm.Success([]byte(TRUE))
 			}
 
 			return boltvm.Error("", "")
@@ -345,24 +388,25 @@ func TestInterchainManager_HandleIBTP(t *testing.T) {
 	assert.False(t, res.Ok)
 	assert.Contains(t, string(res.Result), string(boltvm.InterchainInvalidIBTPParseDestErrorCode))
 
+	//ibtp.From = unexistChainServiceID
+	//ibtp.To = dstChainService.getChainServiceId()
+	//res = im.HandleIBTP(ibtp)
+	//assert.False(t, res.Ok)
+	//assert.Contains(t, string(res.Result), string(boltvm.InterchainSourceAppchainNotAvailableCode))
+
+	//ibtp.From = unavailableChainServiceID
+	//res = im.HandleIBTP(ibtp)
+	//assert.False(t, res.Ok)
+	//assert.Contains(t, string(res.Result), string(boltvm.InterchainSourceAppchainNotAvailableCode))
+
 	// source check failed
-	ibtp.From = unexistChainServiceID
 	ibtp.To = dstChainService.getChainServiceId()
-	res = im.HandleIBTP(ibtp)
-	assert.False(t, res.Ok)
-	assert.Contains(t, string(res.Result), string(boltvm.InterchainSourceAppchainNotAvailableCode))
-
-	ibtp.From = unavailableChainServiceID
-	res = im.HandleIBTP(ibtp)
-	assert.False(t, res.Ok)
-	assert.Contains(t, string(res.Result), string(boltvm.InterchainSourceAppchainNotAvailableCode))
-
-	ibtp.From = unexistServiceServiceID
+	ibtp.From = unexistServiceFullServiceID
 	res = im.HandleIBTP(ibtp)
 	assert.False(t, res.Ok)
 	assert.Contains(t, string(res.Result), string(boltvm.InterchainSourceServiceNotAvailableCode))
 
-	ibtp.From = unavailableServiceServiceID
+	ibtp.From = unavailableServiceFullServiceID
 	res = im.HandleIBTP(ibtp)
 	assert.False(t, res.Ok)
 	assert.Contains(t, string(res.Result), string(boltvm.InterchainSourceServiceNotAvailableCode))
@@ -378,16 +422,19 @@ func TestInterchainManager_HandleIBTP(t *testing.T) {
 	assert.False(t, res.Ok)
 	assert.Contains(t, string(res.Result), string(boltvm.InterchainSourceBitXHubNotAvailableCode))
 
+	//ibtp.From = srcChainService.getChainServiceId()
+	//ibtp.To = unavailableChainServiceID
+	//ibtp.Index = 1
+	//mockStub.EXPECT().PostInterchainEvent(map[string]uint64{srcChainService.ChainId: 1, unavailableChainID: 1}).MaxTimes(1)
+	//res = im.HandleIBTP(ibtp)
+	//assert.True(t, res.Ok)
+
 	// destination check failed
 	ibtp.From = srcChainService.getChainServiceId()
-	ibtp.To = unavailableChainServiceID
+	ibtp.To = unavailableDstServiceFullServiceID
 	ibtp.Index = 1
-	mockStub.EXPECT().PostInterchainEvent(map[string]uint64{srcChainService.ChainId: 1, unavailableChainID: 1}).MaxTimes(1)
-	res = im.HandleIBTP(ibtp)
-	assert.True(t, res.Ok)
-
-	ibtp.To = unavailableDstServiceServiceID
-	mockStub.EXPECT().PostInterchainEvent(map[string]uint64{srcChainService.ChainId: 1, dstChainService.ChainId: 1}).MaxTimes(1)
+	mockStub.EXPECT().PostInterchainEvent(map[string]uint64{srcChainService.ChainId: 1, dstChainID: 1}).MaxTimes(1)
+	mockStub.EXPECT().PostInterchainEvent(map[string]uint64{dstChainID: 1}).MaxTimes(1)
 	res = im.HandleIBTP(ibtp)
 	assert.True(t, res.Ok)
 
@@ -442,14 +489,6 @@ func TestInterchainManager_HandleIBTP(t *testing.T) {
 	mockStub.EXPECT().CrossInvoke(constant.TransactionMgrContractAddr.Address().String(), gomock.Eq("Report"), gomock.Any(), gomock.Any()).Return(boltvm.Success(data)).Times(1)
 	res = im.HandleIBTP(ibtp)
 	assert.True(t, res.Ok, string(res.Result))
-
-	mockStub.EXPECT().GetObject(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-	res = im.GetInterchainInfo(srcChainService.getFullServiceId())
-	assert.True(t, res.Ok, string(res.Result))
-	info := &InterchainInfo{}
-	err = json.Unmarshal(res.Result, info)
-	assert.Nil(t, err)
-	assert.Equal(t, uint64(1), info.InterchainCounter)
 }
 
 func TestInterchainManager_DeleteInterchain(t *testing.T) {


### PR DESCRIPTION
1. Fix the bug of not checking the availability of the destination service when the source service is not local.

2. Delete the redundant appchain availability check when checking IBTP to reduce cross-contract calls. If a service is available, the appchain must be available, and if a service is not available, the availability of the appchain is irrelevant.

3. Simplify the way of checking the availability of appchain (including relay chain) and service. Instead of returning a Masshal object across a contract call and then unmarshal to fetch the state, the process now returns the state directly across a contract call.

4. Delete the repeated operation on cross-contract call of query destination service info when checking index. The destination service info is already obtained when querying the availability of the destination service, so there is no need to make another cross-contract call when checking index.

5. Delete InterchainInfo structure and its storage operations in the contract. This structure was implemented for older browsers and is no longer suitable for IBTP2.0.